### PR TITLE
Compile lm bench

### DIFF
--- a/lmbench/src/compile_lmbench.sh
+++ b/lmbench/src/compile_lmbench.sh
@@ -37,30 +37,11 @@ ENABLE_WASI_THREADS="${ENABLE_WASI_THREADS:-1}"
 WASM_OPT="${WASM_OPT:-$LIND_WASM_ROOT/tools/binaryen/bin/wasm-opt}"
 
 WASMTIME_PROFILE="${WASMTIME_PROFILE:-release}"
-# Prefer system/installed wasmtime first
-WASMTIME="${WASMTIME:-$(command -v wasmtime || true)}"
-
-# Then common lind layouts
-if [[ -z "${WASMTIME}" ]]; then
-  for cand in \
-    "$LIND_WASM_ROOT/build/wasmtime" \
-    "$LIND_WASM_ROOT/build/wasmtime-debug" \
-    "$LIND_WASM_ROOT/build/wasmtime-release" \
-    "$LIND_WASM_ROOT/build/wasmtime/target/${WASMTIME_PROFILE}/wasmtime" \
-    "$LIND_WASM_ROOT/build/wasmtime/target/release/wasmtime" \
-    "$LIND_WASM_ROOT/build/wasmtime/target/debug/wasmtime" \
-    "$LIND_WASM_ROOT/build/target/${WASMTIME_PROFILE}/wasmtime" \
-    "$LIND_WASM_ROOT/build/target/release/wasmtime" \
-    "$LIND_WASM_ROOT/build/target/debug/wasmtime" \
-    "$LIND_WASM_ROOT/wasmtime/target/${WASMTIME_PROFILE}/wasmtime" \
-    "$LIND_WASM_ROOT/wasmtime/target/release/wasmtime" \
-    "$LIND_WASM_ROOT/wasmtime/target/debug/wasmtime" \
-    "$LIND_WASM_ROOT/src/wasmtime/target/${WASMTIME_PROFILE}/wasmtime" \
-    "$LIND_WASM_ROOT/src/wasmtime/target/release/wasmtime" \
-    "$LIND_WASM_ROOT/src/wasmtime/target/debug/wasmtime"
-  do
-    [[ -x "$cand" ]] && { WASMTIME="$cand"; break; }
-  done
+WASMTIME="${WASMTIME:-$LIND_WASM_ROOT/build/wasmtime}"
+# Fallback to release if the requested profile isn't built yet.
+if [[ ! -x "${WASMTIME}" ]]; then
+  echo "ERROR: wasmtime missing: ${WASMTIME}" >&2
+  exit 127 # Note: This is the traditional "command not found" exit code, can be changed as needed
 fi
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
### ISSUE

- After building `lmbench` via `lind-wasm-apps`, the generated WASI binaries do not run reliably under the Lind runtime.
- Both `lind_run` and raw `wasmtime` panicked with `Result::unwrap()` errors for all binaries.

### CHANGES

- Added configurable `MAX_WASM_MEMORY` and `ENABLE_WASI_THREADS` environment variables with sensible defaults.
- Introduced a `supports_cflag` helper to probe clang feature support before enabling WASM threading and atomics flags.
- Constructed `LDFLAGS_WASM` with explicit WASM memory/export linker flags.
- Enabled shared-memory and linker flags, along with `-pthread`, `-matomics`, and `-mbulk-memory` when supported.
- Updated staging and post-processing filters to skip generated artifacts (`*.cwasm`, `*.opt.wasm`, `*.opt.wasm.cwasm`) to prevent re-staging.

### TESTING NOTES

Post compile, this woreks:
```
"$LIND_WASM_ROOT/scripts/lind_run" build/bin/lmbench/wasm32-wasi/hello.opt.wasm
echo "exit=$?"
```
Producing:
```
[LIND DEBUG NUM]: 0
[LIND DEBUG STR]: LIND DEGUG INIT
Hello world
exit=0
```

This one does not:

```
"$LIND_WASM_ROOT/scripts/lind_run" build/bin/lmbench/wasm32-wasi/lat_syscall.opt.wasm -P 1 -W 0 -N 1 null
```

Output:
```
[LIND DEBUG NUM]: 0
[LIND DEBUG STR]: LIND DEGUG INIT

thread 'lind-fork-2' (37693) panicked at crates/rawposix/src/net_calls.rs:339:44:
misaligned pointer dereference: address must be a multiple of 0x8 but is 0x77739802f70c
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
thread caused non-unwinding panic. aborting.
Aborted (core dumped)
```

My interpretation is, given that:
- hello.opt.wasm executes cleanly and exits with status 0, and
- lat_syscall.opt.wasm panics inside crates/rawposix/src/net_calls.rs with a misaligned pointer dereference,

this suggests to me that the remaining failure is occurring within the Lind runtime rather than being caused by an lmbench compilation or staging issue.