### PR TITLE
Ignore getppid == 1 logic to allow lmbench to work with lind-wasm

### DIFF
--- a/lmbench/src/lib_timing.c
+++ b/lmbench/src/lib_timing.c
@@ -680,13 +680,13 @@ benchmp_interval(void* _state)
 		settime(result >= 0. ? (uint64)result : 0.);
 	}
 
-	/* if the parent died, then give up */
-	if (getppid() == 1 && state->cleanup) {
-		if (benchmp_sigchld_handler == SIG_DFL)
-			signal(SIGCHLD, SIG_DFL);
-		(*state->cleanup)(0, state->cookie);
-		exit(0);
-	}
+	// /* if the parent died, then give up */
+	// if (getppid() == 1 && state->cleanup) {
+	// 	if (benchmp_sigchld_handler == SIG_DFL)
+	// 		signal(SIGCHLD, SIG_DFL);
+	// 	(*state->cleanup)(0, state->cookie);
+	// 	exit(0);
+	// }
 
 	timeout.tv_sec = 0;
 	timeout.tv_usec = 0;


### PR DESCRIPTION
Currently, any forked test within lmbench checks whether ppid == 1 to check if parent has died but in lind-wasm, by convention, the first cage is always have pid = 1 meaning some tests are bound to fail. For now, the idea is to ignore this check as this doesn't affect the functionality of lmbench