### PR TITLE
fix: add DNO_PORTMAPPER to lmbench compile script

### DIFF
--- a/lmbench/src/compile_lmbench.sh
+++ b/lmbench/src/compile_lmbench.sh
@@ -119,7 +119,7 @@ LM_BENCH_BIN_DIR="$REPO_ROOT/lmbench/bin/wasm32-wasi"
 mkdir -p "$LM_BENCH_BIN_DIR"
 
 REAL_CC="$CLANG --target=wasm32-unknown-wasi --sysroot=$MERGED_SYSROOT"
-CFLAGS="-O2 -g -I$MERGED_SYSROOT/include -I$MERGED_SYSROOT/include/wasm32-wasi -I$MERGED_SYSROOT/include/tirpc"
+CFLAGS="-DNO_PORTMAPPER -O2 -g -I$MERGED_SYSROOT/include -I$MERGED_SYSROOT/include/wasm32-wasi -I$MERGED_SYSROOT/include/tirpc"
 LDFLAGS_WASM=(
   "-Wl,--import-memory,--export-memory,--max-memory=${MAX_WASM_MEMORY},--export=__stack_pointer,--export=__stack_low,--export=__tls_base"
 "-L$MERGED_SYSROOT/lib/wasm32-wasi"


### PR DESCRIPTION
Without `DNO_PORTMAPPER`, lmbench uses pmap_set()/pmap_getport() (RPC portmapper) to register and discover server ports. Portmapper requires an rpcbind daemon running on the system, which lind-wasm doesn't have. With `DNO_PORTMAPPER`, lmbench uses hardcoded port numbers directly.

This fixes lat_udp lmbench test.

This was found by investigating the source code of lmbench's https://github.com/intel/lmbench/blob/11636a62695bb616b4454f8292ebfcef9eee57c2/src/lib_udp.c#L37