### PR TITLE
Git test suite

### DIFF
--- a/git/run_tests.sh
+++ b/git/run_tests.sh
@@ -28,7 +28,7 @@ fi
 
 LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run"
 LINDFS_ROOT="$LIND_WASM_ROOT/lindfs"
-GIT_BIN="bin/git"
+GIT_BIN="usr/local/bin/git"
 REPO_PATH="/tmp/git-test-repo"
 HOST_REPO_PATH="$LINDFS_ROOT$REPO_PATH"
 REMOTE_PATH="/tmp/git-test-remote.git"


### PR DESCRIPTION
Closes #117 
# Add git test suite for lind-wasm

35//36 tests pass. 
[This issue](https://github.com/Lind-Project/lind-wasm-apps/issues/172) tracks the progress of the failed test

## Summary

Adds a self-contained test runner (`git/run_tests.sh`) that verifies git functionality within the Lind sandbox. **35/36 tests pass.**

## What's included

**`git/test.sh`** — Test runner with 36 test cases covering:

**Basic functionality (3):**
- Binary exists at `lindfs/bin/git`
- `git --version` returns valid output
- `git --help` returns usage info

**Repository setup & config (4):**
- `git init` creates a new repository
- `git config user.name` set and read back
- `git config user.email` set and read back
- `git config --list` shows all config entries

**Staging & commits (5):**
- `git add` stages a new file
- `git commit` creates a commit
- `git status` on empty repo (nothing to commit)
- `git status` after commit (clean working tree)
- `git commit` on a modified file

**History & inspection (4):**
- `git log` shows commit message
- `git log --format` with custom format string
- `git log` with multiple commits
- `git show` displays commit details

**Branching & merging (4):**
- `git branch` creates a new branch
- `git checkout` switches to branch
- `git checkout` switches back to master
- `git merge` fast-forwards a branch

**Tags (2):**
- Lightweight tag (`git tag v1.0`)
- Annotated tag (`git tag -a v2.0 -m "..."`)

**Diff (2):**
- `git diff` shows modified file changes
- `git diff --stat` shows file-level summary

**File operations (2):**
- `git rm` removes a tracked file
- `git mv` renames a tracked file

**Advanced / plumbing (4):**
- `git reset --soft` moves HEAD back one commit
- `git rev-parse HEAD` returns a valid SHA
- `git cat-file -t` identifies object type
- `git hash-object` computes object hash

**Remote operations (6):**
- `git clone --bare` — sets up a bare repo as a local remote
- `git clone` — clones from the bare remote, verifies history
- `git remote -v` — verifies origin URL in cloned repo
- `git push` — commits in the clone and pushes to the bare remote
- `git remote add` — adds the remote to the original repo
- `git pull` — pulls pushed changes back into the original repo

> **Note:** git's local transport uses `fork()`, which triggers a Lind runtime panic (`signal.rs: "thread id does not exist!"`). The remote tests work around this by simulating the transport layer (copying objects/refs on the host filesystem) while using real git commands inside Lind for init, commit, merge, log, remote add, etc. This still validates that git can operate across multiple repos with remote-tracking branches.

## How it works

1. Creates a temp repo at `lindfs/tmp/git-test-repo/`
2. Runs `lind_run bin/git` for each operation in sequence (tests build on each other)
3. For remote tests, creates a bare remote at `lindfs/tmp/git-test-remote.git/` and a clone at `lindfs/tmp/git-test-clone/`
4. Verifies output and repo state after each command
5. Cleans up all repos on exit
6. Exits 0 on all pass, 1 on any failure

## Setup requirements

- git compiled and copied to `lindfs/bin/git`
- `/dev/urandom` and `/dev/random` device nodes in lindfs (script creates them if missing — required for temp file creation)
- git templates in `lindfs/usr/local/share/git-core/templates` (script copies them if missing)

## Key findings

- **`/dev/urandom` required:** `git init` fails with "unable to get random bytes for temporary file" without it
- **git templates required:** `git init` warns "templates not found" without `usr/local/share/git-core/templates` in lindfs
- **`fork()` panics in Lind:** `git clone`, `git fetch`, and `git push` all use fork for local transport, which crashes with a signal handler panic. Remote tests simulate the transport layer as a workaround.
- **`git stash` does not work:** requires forking a subprocess (`git-stash`), fails with "cannot run" error. Not included in tests.
- **`git maintenance` warning:** commits produce a harmless "error: cannot run maintenance: No such file or directory" warning (background process spawning)

## Test results

```
[git-test] 35/36 tests passed, 1 failed
```
`git rm` fails with the error

```
[git-test]        output: error: cannot run maintenance: No such file or directory
[master 7f87eda] add removeme
 1 file changed, 1 insertion(+)
```

## Usage

```bash
cd ~/lind-wasm/lind-wasm-apps
./git/run_tests.sh
```
