### PR TITLE
Updated make install to copy app build folder to lindfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,28 +258,28 @@ postgres: merge-sysroot
 	mkdir -p '$(APPS_BIN_DIR)/postgres/wasm32-wasi'
 
 install-bash:
-	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BIN_DIR)' bash
+	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BUILD)' bash
 
 install-nginx:
-	'$(APPS_ROOT)/nginx/nginx_post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BIN_DIR)'
+	'$(APPS_ROOT)/nginx/nginx_post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BUILD)' nginx
 
 install-git:
-	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BIN_DIR)' git
+	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BUILD)' git
 
 install-curl:
-	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BIN_DIR)' curl
+	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BUILD)' curl
 
 install-grep:
-	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BIN_DIR)' grep
+	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BUILD)' grep
 
 install-sed:
-	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BIN_DIR)' sed
+	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BUILD)' sed
 
 install-lmbench:
-	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BIN_DIR)' lmbench
+	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BUILD)' lmbench
 
 install-coreutils:
-	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BIN_DIR)' coreutils
+	'$(APPS_ROOT)/scripts/post_install.sh' '$(LINDFS_ROOT)' '$(APPS_BUILD)' coreutils
 
 install: install-bash install-nginx install-git install-curl install-grep install-sed install-lmbench install-coreutils
 

--- a/scripts/post_install.sh
+++ b/scripts/post_install.sh
@@ -5,9 +5,4 @@ LINDFS_ROOT="$1"
 APPS_BIN_DIR="$2"
 APP_NAME="$3"
 
-mkdir -p "$LINDFS_ROOT/bin"
-for f in "$APPS_BIN_DIR/$APP_NAME/wasm32-wasi/"*.cwasm; do
-  [ -f "$f" ] || continue
-  base="$(basename "$f" .cwasm)"
-  cp "$f" "$LINDFS_ROOT/bin/$base"
-done
+rsync -av "$APPS_BIN_DIR/$APP_NAME/" "$LINDFS_ROOT/"


### PR DESCRIPTION
Updated the make install to follow the standards specified in #124.

The app build script is expected to copy all required files (binaries, shared libraries, configuration files, log files etc) to `lind-wasm-apps/build/$app` directory.

The `install` target for each app will copy everything (files and subfolders) within `lind-wasm-apps/build/$app` to the `lindfs/` folder.