### PR TITLE
Fix bash call_indirect type mismatches for WASM 

### DIFF
--- a/bash/unwind_prot.c
+++ b/bash/unwind_prot.c
@@ -120,7 +120,7 @@ without_interrupts (function, arg1, arg2)
   old_interrupt_immediately = interrupt_immediately;
   interrupt_immediately = 0;
 
-  (*function)(arg1, arg2);
+  ((void (*)(char *, char *))function)(arg1, arg2);
 
   interrupt_immediately = old_interrupt_immediately;
 }
@@ -330,7 +330,10 @@ unwind_frame_run_internal (tag, ignore)
 	  if (elt->head.cleanup == (Function *) restore_variable)
 	    restore_variable (&elt->sv.v);
 	  else
-	    (*(elt->head.cleanup)) (elt->arg.v);
+        if (elt->arg.v)
+          ((void (*)(char *))(elt->head.cleanup))(elt->arg.v);
+        else
+          ((void (*)(void))(elt->head.cleanup))();
 	}
 
       uwpfree (elt);


### PR DESCRIPTION
Bash uses K&R-style function pointer typedefs (typedef int Function (), typedef void VFunction ()) with unspecified parameters throughout its unwind protect mechanism. In native C, calling through these mistyped pointers is harmless UB. In WASM, call_indirect enforces strict type matching and traps on any mismatch.                                              
                                                                                                                                                                                     
Changes in unwind_prot.c:                                           
- Line 124 (without_interrupts): Cast the VFunction * call to void (*)(char *, char *) to match the actual callee signatures
- Line 333 (cleanup dispatch): Split into two paths based on whether the cleanup arg is NULL — no-arg cleanup functions (set_history_remembering, pop_stream, etc.) are called as    
void (*)(void), while arg-taking cleanups are called as void (*)(char *)
