### PR TITLE
lmbench: add fpu cast flag to fix indirect call type mismatch

### DIFF
--- a/lmbench/src/compile_lmbench.sh
+++ b/lmbench/src/compile_lmbench.sh
@@ -118,7 +118,7 @@ run_wasm_opt_replace() {
   local out="$3"
   local tmp="${out}.tmp"
   cp "$src" "$raw"
-  if "$WASM_OPT" --epoch-injection --asyncify --debuginfo -O2 "$raw" -o "$tmp"; then
+  if "$WASM_OPT" --fpcast-emu --epoch-injection --asyncify --debuginfo -O2 "$raw" -o "$tmp"; then
     mv "$tmp" "$out"
   else
     rm -f "$tmp"


### PR DESCRIPTION
To fix the `"Error: wasm trap: indirect call type mismatch"` error while running lmbench tests that rely on signal handling in lind-wasm, this flag allows two of the remaining lmbench tests succeed: 

```
lind@08c03cf3396e:~/lind-wasm$ sudo /home/lind/lind-wasm/scripts/lind_run /lmbench/bin/lat_sig catch
Signal handler overhead: 2.0419 microseconds
```
and 
```
lind@08c03cf3396e:~/lind-wasm$ sudo /home/lind/lind-wasm/scripts/lind_run /lmbench/bin/memsize
1
```