### PR TITLE
added ca cert copy into post_install script

### DIFF
--- a/curl/compile_curl.sh
+++ b/curl/compile_curl.sh
@@ -218,6 +218,17 @@ else
   exit 1
 fi
 
+# ----------------------------------------------------------------------
+# 10) Stage CA certificate bundle
+# ----------------------------------------------------------------------
+CA_BUNDLE_DEST="$APPS_BUILD/curl/etc/ssl/certs"
+mkdir -p "$CA_BUNDLE_DEST"
+if [[ -f /etc/ssl/certs/ca-certificates.crt ]]; then
+  cp /etc/ssl/certs/ca-certificates.crt "$CA_BUNDLE_DEST/ca-certificates.crt"
+  echo "[curl] CA bundle staged to $CA_BUNDLE_DEST"
+else
+  echo "[curl] WARNING: /etc/ssl/certs/ca-certificates.crt not found on host; HTTPS may fail at runtime."
+fi
 
 echo
 echo "[curl] build complete. Outputs under:"

--- a/scripts/post_install.sh
+++ b/scripts/post_install.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 LINDFS_ROOT="$1"
 APPS_BIN_DIR="$2"
 APP_NAME="$3"
-
 rsync -av "$APPS_BIN_DIR/$APP_NAME/" "$LINDFS_ROOT/"
+
+# Copy CA bundle for curl HTTPS support
+if [[ "$APP_NAME" == "curl" ]]; then
+    mkdir -p "$LINDFS_ROOT/etc/ssl/certs"
+    cp /etc/ssl/certs/ca-certificates.crt "$LINDFS_ROOT/etc/ssl/certs/ca-certificates.crt"
+fi
+

--- a/scripts/post_install.sh
+++ b/scripts/post_install.sh
@@ -3,11 +3,6 @@ set -euo pipefail
 LINDFS_ROOT="$1"
 APPS_BIN_DIR="$2"
 APP_NAME="$3"
-rsync -av "$APPS_BIN_DIR/$APP_NAME/" "$LINDFS_ROOT/"
 
-# Copy CA bundle for curl HTTPS support
-if [[ "$APP_NAME" == "curl" ]]; then
-    mkdir -p "$LINDFS_ROOT/etc/ssl/certs"
-    cp /etc/ssl/certs/ca-certificates.crt "$LINDFS_ROOT/etc/ssl/certs/ca-certificates.crt"
-fi
+rsync -av "$APPS_BIN_DIR/$APP_NAME/" "$LINDFS_ROOT/"
 


### PR DESCRIPTION
## Description
Ca certification needs to by copied from the host system into lindfs/etc/ssl/certs. This is done during make install-curl