### PR TITLE
Enable dynamic build and .cwasm generation for core libraries (gnulib, libtirpc, openssl, zlib)

### DIFF
--- a/gnulib/compile_gnulib.sh
+++ b/gnulib/compile_gnulib.sh
@@ -22,6 +22,9 @@ CC_WASI="$LLVM_BIN/clang --target=wasm32-unknown-wasi --sysroot=$BASE_SYSROOT"
 AR="$LLVM_BIN/llvm-ar"
 RANLIB="$LLVM_BIN/llvm-ranlib"
 
+LIND_DYLINK="${LIND_DYLINK:-0}"
+WASM_OPT="${WASM_OPT:-$LIND_WASM_ROOT/tools/binaryen/bin/wasm-opt}"
+
 # Where your gnulib checkout lives
 GNULIB_DIR="${GNULIB_DIR:-$REPO_ROOT/gnulib}"
 
@@ -85,15 +88,22 @@ if [[ -x ./bootstrap ]]; then
   ./bootstrap --no-git --skip-po || true
 fi
 
+if [[ "$LIND_DYLINK" == "1" ]]; then
+    EXTRA_CFLAGS="-fPIC"
+    CONFIG_ARGS="--enable-shared --disable-static"
+else
+    EXTRA_CFLAGS=""
+    CONFIG_ARGS="--disable-shared --enable-static"
+fi
+
 CC="$CC_WASI" AR="$AR" RANLIB="$RANLIB" \
-CFLAGS="--sysroot=$BASE_SYSROOT -O2 -g" \
+CFLAGS="--sysroot=$BASE_SYSROOT -O2 -g $EXTRA_CFLAGS" \
 LDFLAGS="--sysroot=$BASE_SYSROOT" \
 PKG_CONFIG=false \
 ./configure \
   --host=wasm32-unknown-wasi \
-  --disable-shared \
-  --enable-static \
   --disable-nls \
+  $CONFIG_ARGS \
   "${CACHE_VARS[@]}"
 
 make -j
@@ -130,6 +140,63 @@ fi
 
 popd >/dev/null
 
-echo "[gnulib] done → $OVERLAY/usr/lib/wasm32-wasi/libgnu.a"
-echo "[gnulib] headers → $OVERLAY/usr/include/gnulib/"
+if [[ "$LIND_DYLINK" != "1" ]]; then
+	echo "[gnulib] done → $OVERLAY/usr/lib/wasm32-wasi/libgnu.a"
+	echo "[gnulib] headers → $OVERLAY/usr/include/gnulib/"
+	exit 0
+fi
 
+mkdir -p "$OVERLAY/lib"
+ADD_EXPORT_TOOL="$LIND_WASM_ROOT/tools/add-export-tool/add-export-tool"
+
+STATIC_LIB="$OVERLAY/usr/lib/wasm32-wasi/libgnu.a"
+DYNAMIC_LIB_WASM="$OVERLAY/usr/lib/wasm32-wasi/libgnu.wasm"
+DYNAMIC_LIB_OPT="$OVERLAY/usr/lib/wasm32-wasi/libgnu.opt.wasm"
+DYNAMIC_LIB_OPT_CWASM="$OVERLAY/usr/lib/wasm32-wasi/libgnu.opt.cwasm"
+DYNAMIC_STAGED_LIB="$OVERLAY/lib/libgnu.so"
+"$LLVM_BIN/clang" \
+    --target=wasm32-unknown-wasi \
+    -fPIC \
+    --sysroot "$BASE_SYSROOT" \
+    -fvisibility=default \
+    -Wl,--import-memory \
+    -Wl,--shared-memory \
+    -Wl,--export-dynamic \
+    -Wl,--experimental-pic \
+    -Wl,--unresolved-symbols=import-dynamic \
+    -Wl,-shared \
+    -Wl,--whole-archive \
+    "$STATIC_LIB" \
+    -Wl,--no-whole-archive \
+    "$LIND_WASM_ROOT/src/glibc/build/lind_debug.o" \
+    -g -O0 -o "$DYNAMIC_LIB_WASM" || { echo "[libgnu] ERROR: clang compilation failed"; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_WASM" ]]; then
+  echo "[libgnu] ERROR: Failed to generate '$DYNAMIC_LIB_WASM'; Exiting.."
+  exit 1
+fi
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM" __wasm_apply_tls_relocs func __wasm_apply_tls_relocs optional || { echo "[libgnu] ERROR: add-export-tool tls failed"; exit 1; }
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM" __wasm_apply_global_relocs func __wasm_apply_global_relocs optional || { echo "[libgnu] ERROR: add-export-tool global failed"; exit 1; }
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM"  __stack_pointer global __stack_pointer optional || { echo "[libgnu] ERROR: add-export-tool stack pointer failed"; exit 1; }
+
+
+$WASM_OPT --enable-bulk-memory --enable-threads --epoch-injection --pass-arg=epoch-import --asyncify --pass-arg=asyncify-import-globals -O2 --debuginfo "$DYNAMIC_LIB_WASM" -o "$DYNAMIC_LIB_OPT" || { echo "[libgnu] ERROR: wasm-opt failed on '$DYNAMIC_LIB_OPT'; Exiting.."; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
+  echo "[libgnu] ERROR: Failed to generate '$DYNAMIC_LIB_OPT'; Exiting.."
+  exit 1
+fi
+
+# do precompile
+$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT"|| { echo "[libgnu] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
+  echo "[libgnu] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."
+  exit 1
+fi
+
+cp "$DYNAMIC_LIB_OPT_CWASM" "$DYNAMIC_STAGED_LIB"
+echo "[libgnu] Dynamic shared library staged as $DYNAMIC_STAGED_LIB"

--- a/gnulib/compile_gnulib.sh
+++ b/gnulib/compile_gnulib.sh
@@ -200,7 +200,7 @@ if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
 fi
 
 # do precompile
-$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT"|| { echo "[libgnu] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
+$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[libgnu] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
 
 if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
   echo "[libgnu] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."

--- a/gnulib/compile_gnulib.sh
+++ b/gnulib/compile_gnulib.sh
@@ -88,13 +88,22 @@ if [[ -x ./bootstrap ]]; then
   ./bootstrap --no-git --skip-po || true
 fi
 
+# ---------------------------------------------------------
+# Branch libgnu build flags based on Dylink mode
+# ---------------------------------------------------------
 if [[ "$LIND_DYLINK" == "1" ]]; then
-    EXTRA_CFLAGS="-fPIC"
-    CONFIG_ARGS="--enable-shared --disable-static"
+  echo "[libgnu] Building with PIC and default visibility for Dynamic Linking..."
+  EXTRA_CFLAGS="-fPIC -fvisibility=default"
+  # We MUST keep static enabled to avoid libtool/wasm-ld ELF errors,
+  # but the -fPIC flag above ensures the objects inside libgnu.a are position-independent.
+  CONFIG_ARGS="--disable-shared --enable-static"
 else
-    EXTRA_CFLAGS=""
-    CONFIG_ARGS="--disable-shared --enable-static"
+  echo "[libgnu] Building standard static objects for Static Linking..."
+  EXTRA_CFLAGS=""
+  CONFIG_ARGS="--disable-shared --enable-static"
 fi
+
+
 
 CC="$CC_WASI" AR="$AR" RANLIB="$RANLIB" \
 CFLAGS="--sysroot=$BASE_SYSROOT -O2 -g $EXTRA_CFLAGS" \

--- a/libtirpc/compile_libtirpc.sh
+++ b/libtirpc/compile_libtirpc.sh
@@ -29,12 +29,32 @@ echo "[libtirpc] CC=$CC_WASI"
 pushd "$REPO_ROOT/libtirpc" >/dev/null
 
 autoreconf -fi
+
+# ---------------------------------------------------------
+# Branch libtirpc build flags based on Dylink mode
+# ---------------------------------------------------------
+if [[ "$LIND_DYLINK" == "1" ]]; then
+  echo "[libtirpc] Building with PIC and default visibility for Dynamic Linking..."
+  EXTRA_CFLAGS="-fPIC -fvisibility=default"
+  CONFIG_ARGS="--disable-shared --enable-static --with-pic"
+else
+  echo "[libtirpc] Building standard static objects for Static Linking..."
+  EXTRA_CFLAGS=""
+  CONFIG_ARGS="--disable-shared --enable-static"
+fi
+
 CC="$CC_WASI" AR="$AR" RANLIB="$RANLIB" \
-CFLAGS="--sysroot=$BASE_SYSROOT -O2 -g" \
+CFLAGS="--sysroot=$BASE_SYSROOT -O2 -g $EXTRA_CFLAGS" \
 LDFLAGS="--sysroot=$BASE_SYSROOT" \
 PKG_CONFIG=false \
-./configure --host=wasm32-unknown-wasi --disable-gssapi --disable-shared --enable-static --with-pic --sysconfdir=/etc \
-  ac_cv_func_malloc_0_nonnull=yes ac_cv_func_memset=yes ac_cv_func_strchr=yes
+./configure --host=wasm32-unknown-wasi \
+  --disable-gssapi \
+  $CONFIG_ARGS \
+  --sysconfdir=/etc \
+  ac_cv_func_malloc_0_nonnull=yes \
+  ac_cv_func_memset=yes \
+  ac_cv_func_strchr=yes
+
 
 make -j
 rsync -a "tirpc/" "$OVERLAY/usr/include/tirpc/"

--- a/libtirpc/compile_libtirpc.sh
+++ b/libtirpc/compile_libtirpc.sh
@@ -8,7 +8,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 BASE_SYSROOT="${BASE_SYSROOT:-$LIND_WASM_ROOT/src/glibc/sysroot}"
 LLVM_BIN="${LLVM_BIN:-$(ls -d "$LIND_WASM_ROOT"/clang+llvm-*/bin 2>/dev/null | head -n1)}"
-
+WASM_OPT="${WASM_OPT:-$LIND_WASM_ROOT/tools/binaryen/bin/wasm-opt}"
 if [[ -z "${LLVM_BIN}" || ! -x "$LLVM_BIN/clang" ]]; then
   echo "ERROR: LLVM not found under $LIND_WASM_ROOT"; exit 1
 fi
@@ -22,6 +22,7 @@ RANLIB="$LLVM_BIN/llvm-ranlib"
 
 OVERLAY="$REPO_ROOT/build/sysroot_overlay"
 MERGE_TMP="$OVERLAY/usr/lib/wasm32-wasi/merge_tmp"
+LIND_DYLINK="${LIND_DYLINK:-0}"
 mkdir -p "$OVERLAY/usr/include/tirpc" "$MERGE_TMP"
 
 echo "[libtirpc] CC=$CC_WASI"
@@ -42,4 +43,64 @@ find "src" -name '*.o' -exec cp {} "$MERGE_TMP/" \;
 "$RANLIB" "$OVERLAY/usr/lib/wasm32-wasi/libtirpc.a"
 
 popd >/dev/null
-echo "[libtirpc] done → $OVERLAY/usr/lib/wasm32-wasi/libtirpc.a"
+if [[ "$LIND_DYLINK" != "1" ]]; then
+	echo "[libtirpc] done → $OVERLAY/usr/lib/wasm32-wasi/libtirpc.a"
+	exit 0
+fi
+
+mkdir -p "$OVERLAY/lib"
+ADD_EXPORT_TOOL="$LIND_WASM_ROOT/tools/add-export-tool/add-export-tool"
+
+STATIC_LIB="$OVERLAY/usr/lib/wasm32-wasi/libtirpc.a"
+DYNAMIC_LIB_WASM="$OVERLAY/usr/lib/wasm32-wasi/libtirpc.wasm"
+DYNAMIC_LIB_OPT="$OVERLAY/usr/lib/wasm32-wasi/libtirpc.opt.wasm"
+DYNAMIC_LIB_OPT_CWASM="$OVERLAY/usr/lib/wasm32-wasi/libtirpc.opt.cwasm"
+DYNAMIC_STAGED_LIB="$OVERLAY/lib/libtirpc.so"
+"$LLVM_BIN/clang" \
+    --target=wasm32-unknown-wasi \
+    -fPIC \
+    --sysroot "$BASE_SYSROOT" \
+    -fvisibility=default \
+    -Wl,--import-memory \
+    -Wl,--shared-memory \
+    -Wl,--export-dynamic \
+    -Wl,--experimental-pic \
+    -Wl,--unresolved-symbols=import-dynamic \
+    -Wl,-shared \
+    -Wl,--whole-archive \
+    "$STATIC_LIB" \
+    -Wl,--no-whole-archive \
+    "$LIND_WASM_ROOT/src/glibc/build/lind_debug.o" \
+    -g -O0 -o "$DYNAMIC_LIB_WASM" || { echo "[libtirpc] ERROR: clang compilation failed"; exit 1; }
+
+
+if [[ ! -f "$DYNAMIC_LIB_WASM" ]]; then
+  echo "[libtirpc] ERROR: Failed to generate '$DYNAMIC_LIB_WASM'; Exiting.."
+  exit 1
+fi
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM" __wasm_apply_tls_relocs func __wasm_apply_tls_relocs optional || { echo "[libtirpc] ERROR: add-export-tool tls failed"; exit 1; }
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM" __wasm_apply_global_relocs func __wasm_apply_global_relocs optional || { echo "[libtirpc] ERROR: add-export-tool global failed"; exit 1; }
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM"  __stack_pointer global __stack_pointer optional || { echo "[libtirpc] ERROR: add-export-tool stack pointer failed"; exit 1; }
+
+
+$WASM_OPT --enable-bulk-memory --enable-threads --epoch-injection --pass-arg=epoch-import --asyncify --pass-arg=asyncify-import-globals -O2 --debuginfo "$DYNAMIC_LIB_WASM" -o "$DYNAMIC_LIB_OPT" || { echo "[libtirpc] ERROR: wasm-opt failed on '$DYNAMIC_LIB_OPT'; Exiting.."; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
+  echo "[libtirpc] ERROR: Failed to generate '$DYNAMIC_LIB_OPT'; Exiting.."
+  exit 1
+fi
+
+# do precompile
+$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT"|| { echo "[libtirpc] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
+  echo "[libtirpc] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."
+  exit 1
+fi
+
+cp "$DYNAMIC_LIB_OPT_CWASM" "$DYNAMIC_STAGED_LIB"
+echo "[libtirpc] Dynamic shared library staged as $DYNAMIC_STAGED_LIB"
+

--- a/libtirpc/compile_libtirpc.sh
+++ b/libtirpc/compile_libtirpc.sh
@@ -114,7 +114,7 @@ if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
 fi
 
 # do precompile
-$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT"|| { echo "[libtirpc] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
+$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[libtirpc] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
 
 if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
   echo "[libtirpc] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."

--- a/openssl/compile_openssl.sh
+++ b/openssl/compile_openssl.sh
@@ -16,6 +16,9 @@ if [[ ! -r "$BASE_SYSROOT/include/wasm32-wasi/stdio.h" ]]; then
   echo "ERROR: sysroot headers missing at $BASE_SYSROOT"; exit 1
 fi
 
+LIND_DYLINK="${LIND_DYLINK:-0}"
+WASM_OPT="${WASM_OPT:-$LIND_WASM_ROOT/tools/binaryen/bin/wasm-opt}"
+
 CC_WASI="$LLVM_BIN/clang --target=wasm32-unknown-wasi --sysroot=$BASE_SYSROOT"
 AR="$LLVM_BIN/llvm-ar"
 RANLIB="$LLVM_BIN/llvm-ranlib"
@@ -47,4 +50,116 @@ cp libcrypto.a "$OVERLAY/usr/lib/wasm32-wasi/"
 rsync -a include/openssl/ "$OVERLAY/usr/include/openssl/"
 
 popd >/dev/null
-echo "[openssl] done → $OVERLAY/usr/lib/wasm32-wasi/libssl.a, libcrypto.a"
+if [[ "$LIND_DYLINK" != "1" ]]; then
+	echo "[openssl] done → $OVERLAY/usr/lib/wasm32-wasi/libssl.a, libcrypto.a"
+	exit 0
+fi
+
+mkdir -p "$OVERLAY/lib"
+ADD_EXPORT_TOOL="$LIND_WASM_ROOT/tools/add-export-tool/add-export-tool"
+
+STATIC_LIB="$OVERLAY/usr/lib/wasm32-wasi/libssl.a"
+DYNAMIC_LIB_WASM="$OVERLAY/usr/lib/wasm32-wasi/libssl.wasm"
+DYNAMIC_LIB_OPT="$OVERLAY/usr/lib/wasm32-wasi/libssl.opt.wasm"
+DYNAMIC_LIB_OPT_CWASM="$OVERLAY/usr/lib/wasm32-wasi/libssl.opt.cwasm"
+DYNAMIC_STAGED_LIB="$OVERLAY/lib/libssl.so"
+
+"$LLVM_BIN/clang" \
+    --target=wasm32-unknown-wasi \
+    -fPIC \
+    --sysroot "$BASE_SYSROOT" \
+    -fvisibility=default \
+    -Wl,--import-memory \
+    -Wl,--shared-memory \
+    -Wl,--export-dynamic \
+    -Wl,--experimental-pic \
+    -Wl,--unresolved-symbols=import-dynamic \
+    -Wl,-shared \
+    -Wl,--whole-archive \
+    "$STATIC_LIB" \
+    -Wl,--no-whole-archive \
+    "$LIND_WASM_ROOT/src/glibc/build/lind_debug.o" \
+    -g -O0 -o "$DYNAMIC_LIB_WASM" || { echo "[openssl] ERROR: clang compilation failed"; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_WASM" ]]; then
+  echo "[openssl] ERROR: Failed to generate '$DYNAMIC_LIB_WASM'; Exiting.."
+  exit 1
+fi
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM" __wasm_apply_tls_relocs func __wasm_apply_tls_relocs optional || { echo "[openssl] ERROR: add-export-tool tls failed"; exit 1; }
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM" __wasm_apply_global_relocs func __wasm_apply_global_relocs optional || { echo "[openssl] ERROR: add-export-tool global failed"; exit 1; }
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM"  __stack_pointer global __stack_pointer optional || { echo "[openssl] ERROR: add-export-tool stack pointer failed"; exit 1; }
+
+
+$WASM_OPT --enable-bulk-memory --enable-threads --epoch-injection --pass-arg=epoch-import --asyncify --pass-arg=asyncify-import-globals -O2 --debuginfo "$DYNAMIC_LIB_WASM" -o "$DYNAMIC_LIB_OPT" || { echo "[openssl] ERROR: wasm-opt failed on '$DYNAMIC_LIB_OPT'; Exiting.."; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
+  echo "[openssl] ERROR: Failed to generate '$DYNAMIC_LIB_OPT'; Exiting.."
+  exit 1
+fi
+
+# do precompile
+$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT"|| { echo "[openssl] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
+  echo "[openssl] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."
+  exit 1
+fi
+
+cp "$DYNAMIC_LIB_OPT_CWASM" "$DYNAMIC_STAGED_LIB"
+echo "[openssl] Dynamic shared library staged as $DYNAMIC_STAGED_LIB"
+
+STATIC_LIB="$OVERLAY/usr/lib/wasm32-wasi/libcrypto.a"
+DYNAMIC_LIB_WASM="$OVERLAY/usr/lib/wasm32-wasi/libcrypto.wasm"
+DYNAMIC_LIB_OPT="$OVERLAY/usr/lib/wasm32-wasi/libcrypto.opt.wasm"
+DYNAMIC_LIB_OPT_CWASM="$OVERLAY/usr/lib/wasm32-wasi/libcrypto.opt.cwasm"
+DYNAMIC_STAGED_LIB="$OVERLAY/lib/libcrypto.so"
+"$LLVM_BIN/clang" \
+    --target=wasm32-unknown-wasi \
+    -fPIC \
+    --sysroot "$BASE_SYSROOT" \
+    -fvisibility=default \
+    -Wl,--import-memory \
+    -Wl,--shared-memory \
+    -Wl,--export-dynamic \
+    -Wl,--experimental-pic \
+    -Wl,--unresolved-symbols=import-dynamic \
+    -Wl,-shared \
+    -Wl,--whole-archive \
+    "$STATIC_LIB" \
+    -Wl,--no-whole-archive \
+    "$LIND_WASM_ROOT/src/glibc/build/lind_debug.o" \
+    -g -O0 -o "$DYNAMIC_LIB_WASM" || { echo "[openssl] ERROR: clang compilation failed"; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_WASM" ]]; then
+  echo "[openssl] ERROR: Failed to generate '$DYNAMIC_LIB_WASM'; Exiting.."
+  exit 1
+fi
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM" __wasm_apply_tls_relocs func __wasm_apply_tls_relocs optional || { echo "[openssl] ERROR: add-export-tool tls failed"; exit 1; }
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM" __wasm_apply_global_relocs func __wasm_apply_global_relocs optional || { echo "[openssl] ERROR: add-export-tool global failed"; exit 1; }
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM"  __stack_pointer global __stack_pointer optional || { echo "[openssl] ERROR: add-export-tool stack pointer failed"; exit 1; }
+
+
+$WASM_OPT --enable-bulk-memory --enable-threads --epoch-injection --pass-arg=epoch-import --asyncify --pass-arg=asyncify-import-globals -O2 --debuginfo "$DYNAMIC_LIB_WASM" -o "$DYNAMIC_LIB_OPT" || { echo "[openssl] ERROR: wasm-opt failed on '$DYNAMIC_LIB_OPT'; Exiting.."; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
+  echo "[openssl] ERROR: Failed to generate '$DYNAMIC_LIB_OPT'; Exiting.."
+  exit 1
+fi
+
+# do precompile
+$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT"|| { echo "[openssl] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
+  echo "[openssl] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."
+  exit 1
+fi
+
+cp "$DYNAMIC_LIB_OPT_CWASM" "$DYNAMIC_STAGED_LIB"
+echo "[openssl] Dynamic shared library staged as $DYNAMIC_STAGED_LIB"
+

--- a/openssl/compile_openssl.sh
+++ b/openssl/compile_openssl.sh
@@ -116,7 +116,7 @@ if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
 fi
 
 # do precompile
-$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT"|| { echo "[openssl] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
+$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[openssl] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
 
 if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
   echo "[openssl] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."
@@ -168,7 +168,7 @@ if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
 fi
 
 # do precompile
-$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT"|| { echo "[openssl] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
+$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[openssl] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
 
 if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
   echo "[openssl] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."

--- a/openssl/compile_openssl.sh
+++ b/openssl/compile_openssl.sh
@@ -32,10 +32,25 @@ pushd "$REPO_ROOT/openssl" >/dev/null
 
 make distclean || true
 
+# ---------------------------------------------------------
+# Branch OpenSSL build flags based on Dylink mode
+# ---------------------------------------------------------
+if [[ "$LIND_DYLINK" == "1" ]]; then
+  echo "[openssl] Building with PIC and default visibility for Dynamic Linking..."
+  SSL_CFLAGS="--sysroot=$BASE_SYSROOT -O2 -g -fPIC -fvisibility=default"
+  SSL_PIC_FLAG="enable-pic"
+else
+  echo "[openssl] Building standard static objects for Static Linking..."
+  SSL_CFLAGS="--sysroot=$BASE_SYSROOT -O2 -g"
+  SSL_PIC_FLAG=""
+fi
+
+# Pass the conditional variables into the build environment
 CC="$CC_WASI" AR="$AR" RANLIB="$RANLIB" \
-CFLAGS="--sysroot=$BASE_SYSROOT -O2 -g" \
+CFLAGS="$SSL_CFLAGS" \
 LDFLAGS="--sysroot=$BASE_SYSROOT" \
 ./Configure linux-generic32 \
+  $SSL_PIC_FLAG \
   no-asm no-shared no-dso no-async \
   no-engine no-afalgeng no-ui-console no-tests \
   --prefix="$INSTALL_DIR" --openssldir="$INSTALL_DIR/ssl"

--- a/zlib/compile_zlib.sh
+++ b/zlib/compile_zlib.sh
@@ -54,7 +54,7 @@ cp zlib.h zconf.h "$OVERLAY/usr/include/"
 popd >/dev/null
 
 if [[ "$LIND_DYLINK" != "1" ]]; then
-        echo "[zlib] done ?~F~R $OVERLAY/usr/lib/wasm32-wasi/libz.a"
+        echo "[zlib] done → $OVERLAY/usr/lib/wasm32-wasi/libz.a"
         exit 0
 fi
 
@@ -103,7 +103,7 @@ if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
 fi
 
 # do precompile
-$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT"|| { echo "[zlib] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
+$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[zlib] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
 
 if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
   echo "[zlib] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."

--- a/zlib/compile_zlib.sh
+++ b/zlib/compile_zlib.sh
@@ -16,6 +16,9 @@ if [[ ! -r "$BASE_SYSROOT/include/wasm32-wasi/stdio.h" ]]; then
   echo "ERROR: sysroot headers missing at $BASE_SYSROOT"; exit 1
 fi
 
+LIND_DYLINK="${LIND_DYLINK:-0}"
+WASM_OPT="${WASM_OPT:-$LIND_WASM_ROOT/tools/binaryen/bin/wasm-opt}"
+
 CC_WASI="$LLVM_BIN/clang --target=wasm32-unknown-wasi --sysroot=$BASE_SYSROOT"
 AR="$LLVM_BIN/llvm-ar"
 RANLIB="$LLVM_BIN/llvm-ranlib"
@@ -40,4 +43,63 @@ cp libz.a "$OVERLAY/usr/lib/wasm32-wasi/libz.a"
 cp zlib.h zconf.h "$OVERLAY/usr/include/"
 
 popd >/dev/null
-echo "[zlib] done → $OVERLAY/usr/lib/wasm32-wasi/libz.a"
+
+if [[ "$LIND_DYLINK" != "1" ]]; then
+        echo "[zlib] done ?~F~R $OVERLAY/usr/lib/wasm32-wasi/libz.a"
+        exit 0
+fi
+
+mkdir -p "$OVERLAY/lib"
+ADD_EXPORT_TOOL="$LIND_WASM_ROOT/tools/add-export-tool/add-export-tool"
+
+STATIC_LIB="$OVERLAY/usr/lib/wasm32-wasi/libz.a"
+DYNAMIC_LIB_WASM="$OVERLAY/usr/lib/wasm32-wasi/libz.wasm"
+DYNAMIC_LIB_OPT="$OVERLAY/usr/lib/wasm32-wasi/libz.opt.wasm"
+DYNAMIC_LIB_OPT_CWASM="$OVERLAY/usr/lib/wasm32-wasi/libz.opt.cwasm"
+DYNAMIC_STAGED_LIB="$OVERLAY/lib/libz.so"
+"$LLVM_BIN/clang" \
+    --target=wasm32-unknown-wasi \
+    -fPIC \
+    --sysroot "$BASE_SYSROOT" \
+    -fvisibility=default \
+    -Wl,--import-memory \
+    -Wl,--shared-memory \
+    -Wl,--export-dynamic \
+    -Wl,--experimental-pic \
+    -Wl,--unresolved-symbols=import-dynamic \
+    -Wl,-shared \
+    -Wl,--whole-archive \
+    "$STATIC_LIB" \
+    -Wl,--no-whole-archive \
+    "$LIND_WASM_ROOT/src/glibc/build/lind_debug.o" \
+    -g -O0 -o "$DYNAMIC_LIB_WASM" || { echo "[zlib] ERROR: clang compilation failed"; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_WASM" ]]; then
+  echo "[zlib] ERROR: Failed to generate '$DYNAMIC_LIB_WASM'; Exiting.."
+  exit 1
+fi
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM" __wasm_apply_tls_relocs func __wasm_apply_tls_relocs optional || { echo "[zlib] ERROR: add-export-tool tls failed"; exit 1; }
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM" __wasm_apply_global_relocs func __wasm_apply_global_relocs optional || { echo "[zlib] ERROR: add-export-tool global failed"; exit 1; }
+
+"$ADD_EXPORT_TOOL" "$DYNAMIC_LIB_WASM" "$DYNAMIC_LIB_WASM"  __stack_pointer global __stack_pointer optional || { echo "[zlib] ERROR: add-export-tool stack pointer failed"; exit 1; }
+
+
+$WASM_OPT --enable-bulk-memory --enable-threads --epoch-injection --pass-arg=epoch-import --asyncify --pass-arg=asyncify-import-globals -O2 --debuginfo "$DYNAMIC_LIB_WASM" -o "$DYNAMIC_LIB_OPT" || { echo "[zlib] ERROR: wasm-opt failed on '$DYNAMIC_LIB_OPT'; Exiting.."; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
+  echo "[zlib] ERROR: Failed to generate '$DYNAMIC_LIB_OPT'; Exiting.."
+  exit 1
+fi
+
+# do precompile
+$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT"|| { echo "[zlib] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."; exit 1; }
+
+if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
+  echo "[zlib] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.."
+  exit 1
+fi
+
+cp "$DYNAMIC_LIB_OPT_CWASM" "$DYNAMIC_STAGED_LIB"
+echo "[zlib] Dynamic shared library staged as $DYNAMIC_STAGED_LIB"

--- a/zlib/compile_zlib.sh
+++ b/zlib/compile_zlib.sh
@@ -31,8 +31,17 @@ pushd "$REPO_ROOT/zlib" >/dev/null
 
 make distclean || true
 
+# Branch zlib build flags based on Dylink mode
+if [[ "$LIND_DYLINK" == "1" ]]; then
+  echo "[zlib] Building with PIC and default visibility for Dynamic Linking..."
+  ZLIB_CFLAGS="--sysroot=$BASE_SYSROOT -O2 -g -fPIC -fvisibility=default"
+else
+  echo "[zlib] Building standard static objects for Static Linking..."
+  ZLIB_CFLAGS="--sysroot=$BASE_SYSROOT -O2 -g"
+fi
+
 CC="$CC_WASI" AR="$AR" RANLIB="$RANLIB" \
-CFLAGS="--sysroot=$BASE_SYSROOT -O2 -g" \
+CFLAGS="$ZLIB_CFLAGS" \
 LDFLAGS="--sysroot=$BASE_SYSROOT" \
 ./configure --static --prefix="$OVERLAY/usr"
 


### PR DESCRIPTION
Closes #104 
### **Context**
Previously, our build scripts handled the `configure` and `make` steps for our core libraries producing static archives required for the static build of applications. However, we needed to convert the resulting static archives into fully optimized, dynamically linked WebAssembly shared objects to run the applications with dynamic library support.

This PR introduces the automated steps to link, export, optimize, and precompile the static archives for `gnulib`, `libtirpc`, `openssl`, and `zlib` into dynamic `.cwasm` libraries when dynamic linking is enabled.

### **Proposed Changes**
* **Conditional Execution:** The dynamic build pipeline for each library only triggers if `LIND_DYLINK="1"`. Otherwise, it exits cleanly after the standard static build.
* **Position-Independent Static Archives**: Modifies the underlying configure steps to force static archive generation (--disable-shared --enable-static) while explicitly injecting -fPIC and -fvisibility=default into the CFLAGS. This bypasses legacy Libtool/ELF linking errors that the compiled objects are properly configured to expose their public APIs to the WebAssembly export table during the final shared library generation.
* **Shared WASM Generation:** Links the respective static archives alongside `lind_debug.o` into shared WebAssembly files using `clang` with experimental PIC and shared memory flags.
* **Symbol Exporting:** Uses `add-export-tool` to explicitly export necessary symbols (`__wasm_apply_tls_relocs`, `__wasm_apply_global_relocs`, and `__stack_pointer`) for each library.
* **WASM Optimization & Instrumentation:** Runs `wasm-opt` on the generated files to enable bulk memory, threads, epoch injection, and asyncify.
* **Precompilation:** Uses `lind_compile` to compile the optimized WASM files into their final `.cwasm` formats.
* **Staging:** Copies the final `.cwasm` artifacts to the overlay library directory as standard `.so` files.

### **Technical Details**
* **Clang Linker Flags:** Implements necessary dynamic flags including `-Wl,--import-memory`, `-Wl,--export-dynamic`, and `-Wl,--experimental-pic`. Uses `--whole-archive` to ensure all symbols from the static archives are included in the shared libraries.
* **Error Handling:** Added strict existence checks (`[[ ! -f ... ]]`) and fail-safes (`|| exit 1`) after every major tool execution (`clang`, `add-export-tool`, `wasm-opt`, `lind_compile`) to ensure the build pipeline fails loudly if an intermediate artifact is missing for any of the libraries.


### To test
These libraries can be tested by running the dynamic build of apps. OpenSSL and zlib can be tested with `curl` and `git`. libtirpc can be tested with `lmbench `. 

**Note:** gnulib is always statically linked with coreutils and other apps and hence dynamic build of the library is not essential.