### PR TITLE
Add dynamic build for curl and update tests

### DIFF
--- a/curl/compile_curl.sh
+++ b/curl/compile_curl.sh
@@ -5,12 +5,10 @@ set -euo pipefail
 # curl WASI build helper for lind-wasm-apps
 #
 # Cross-compiles curl for wasm32-wasi with OpenSSL and zlib (both already
-# present in the merged sysroot).  Only HTTP/HTTPS protocols are enabled;
+# present in the merged sysroot). Only HTTP/HTTPS protocols are enabled;
 # everything else is disabled to minimise surface area and link complexity.
 #
-# Prerequisites:
-#   - Run 'make preflight' and 'make merge-sysroot' first
-#   - autoreconf (autoconf/automake/libtool) must be installed on the host
+# Supports both Static (default) and Dynamic (LIND_DYLINK=1) builds.
 ###############################################################################
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -22,7 +20,7 @@ MERGED_SYSROOT="$APPS_BUILD/sysroot_merged"
 STAGE_DIR="$APPS_BUILD/curl/usr/local/bin"
 TOOL_ENV="$APPS_BUILD/.toolchain.env"
 
-# Default LIND_WASM_ROOT to parent directory (layout: lind-wasm/lind-wasm-apps)
+# Default LIND_WASM_ROOT to parent directory
 if [[ -z "${LIND_WASM_ROOT:-}" ]]; then
   LIND_WASM_ROOT="$(cd "$APPS_ROOT/.." && pwd)"
 fi
@@ -31,6 +29,7 @@ WASM_OPT="${WASM_OPT:-$LIND_WASM_ROOT/tools/binaryen/bin/wasm-opt}"
 LIND_BOOT="${LIND_BOOT:-$LIND_WASM_ROOT/build/lind-boot}"
 
 JOBS="${JOBS:-$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN || echo 4)}"
+LIND_DYLINK="${LIND_DYLINK:-0}"
 
 # ----------------------------------------------------------------------
 # 1) Load toolchain from Makefile preflight
@@ -47,7 +46,6 @@ fi
 : "${AR:?missing AR in $TOOL_ENV}"
 : "${RANLIB:?missing RANLIB in $TOOL_ENV}"
 
-# Sanity
 if [[ ! -d "$CURL_ROOT" ]]; then
   echo "[curl] ERROR: curl source dir not found at: $CURL_ROOT" >&2
   exit 1
@@ -60,7 +58,7 @@ fi
 mkdir -p "$STAGE_DIR"
 
 # ----------------------------------------------------------------------
-# 2) WASM toolchain flags
+# 2) Base WASM Toolchain Flags
 # ----------------------------------------------------------------------
 CC_WASM="$CLANG --target=wasm32-unknown-wasi --sysroot=$MERGED_SYSROOT -pthread"
 
@@ -70,32 +68,85 @@ CFLAGS_WASM=(
   -I"$MERGED_SYSROOT/include/wasm32-wasi"
 )
 
-LDFLAGS_WASM=(
-  "-Wl,--import-memory,--export-memory,--max-memory=67108864,--export=__stack_pointer,--export=__stack_low,--export=__tls_base"
-  -L"$MERGED_SYSROOT/lib/wasm32-wasi"
-  -L"$MERGED_SYSROOT/usr/lib/wasm32-wasi"
-)
-
-echo "[curl] using CLANG       = $CLANG"
-echo "[curl] using AR          = $AR"
-echo "[curl] using RANLIB      = $RANLIB"
-echo "[curl] LIND_WASM_ROOT    = $LIND_WASM_ROOT"
-echo "[curl] merged sysroot    = $MERGED_SYSROOT"
-echo "[curl] stage dir         = $STAGE_DIR"
-echo "[curl] CC_WASM           = $CC_WASM"
-echo
-
 # ----------------------------------------------------------------------
-# 3) Force static-only (prevent wasm-ld seeing --shared)
+# 3) Branch Logic: Dynamic vs Static Settings
 # ----------------------------------------------------------------------
-export enable_shared=no
-export enable_static=yes
-export lt_cv_prog_compiler_pic_works=no
-export lt_cv_prog_compiler_static_works=yes
+if [[ "$LIND_DYLINK" == "1" ]]; then
+  echo "[curl] Mode: DYNAMIC LINKING (LIND_DYLINK=1)"
+  CFLAGS_WASM+=(-fPIC)
+
+  ADD_EXPORT_TOOL="$LIND_WASM_ROOT/tools/add-export-tool/add-export-tool"
+  if [[ ! -x "$ADD_EXPORT_TOOL" ]]; then
+    echo "[curl] ERROR: add-export-tool not found at '$ADD_EXPORT_TOOL'" >&2
+    exit 1
+  fi
+
+  DYLINK_CRT_OBJS=(
+    "$MERGED_SYSROOT/lib/wasm32-wasi/set_stack_pointer.o"
+    "$MERGED_SYSROOT/lib/wasm32-wasi/crt1_shared.o"
+    "$MERGED_SYSROOT/lib/wasm32-wasi/lind_utils.o"
+  )
+  for obj in "${DYLINK_CRT_OBJS[@]}"; do
+    if [[ ! -f "$obj" ]]; then
+      echo "[curl] ERROR: required dylink CRT object '$obj' not found." >&2
+      exit 1
+    fi
+  done
+
+  # Flags for the actual build phase
+  LDFLAGS_WASM=(
+    "-nostartfiles"
+    "-Wl,-pie"
+    "-Wl,--import-table"
+    "-Wl,--import-memory"
+    "-Wl,--export-memory"
+    "-Wl,--shared-memory"
+    "-Wl,--max-memory=67108864"
+    "-Wl,--allow-undefined"
+    "-Wl,--unresolved-symbols=import-dynamic"
+    "-Wl,--export=__wasm_call_ctors"
+    "-Wl,--export-if-defined=__wasm_init_tls"
+    "-Wl,--export=__tls_base"
+    -L"$MERGED_SYSROOT/lib/wasm32-wasi"
+    -L"$MERGED_SYSROOT/usr/lib/wasm32-wasi"
+    "${DYLINK_CRT_OBJS[@]}"
+  )
+  
+  # Flags just for ./configure (to pass autoconf feature tests)
+  LDFLAGS_CONFIGURE=(
+    "-Wl,--import-memory,--export-memory,--max-memory=67108864,--export=__stack_pointer,--export=__stack_low,--export=__tls_base"
+    -L"$MERGED_SYSROOT/lib/wasm32-wasi"
+    -L"$MERGED_SYSROOT/usr/lib/wasm32-wasi"
+  )
+
+  # Libtool: Build a Static library, but force it to contain PIC objects
+  # so it can be safely linked into our dynamic PIE executable later.
+  export enable_shared=no
+  export enable_static=yes
+  export lt_cv_prog_compiler_pic_works=yes
+  export lt_cv_prog_compiler_static_works=yes
+  CONFIG_SHARED_FLAGS="--disable-shared --enable-static"
+else
+  echo "[curl] Mode: STATIC LINKING (LIND_DYLINK=0 or unset)"
+  
+  LDFLAGS_WASM=(
+    "-Wl,--import-memory,--export-memory,--max-memory=67108864,--export=__stack_pointer,--export=__stack_low,--export=__tls_base"
+    -L"$MERGED_SYSROOT/lib/wasm32-wasi"
+    -L"$MERGED_SYSROOT/usr/lib/wasm32-wasi"
+  )
+  LDFLAGS_CONFIGURE=("${LDFLAGS_WASM[@]}")
+
+  # Libtool & Configure variables for Static Libraries
+  export enable_shared=no
+  export enable_static=yes
+  export lt_cv_prog_compiler_pic_works=no
+  export lt_cv_prog_compiler_static_works=yes
+  CONFIG_SHARED_FLAGS="--disable-shared --enable-static"
+fi
 
 export CFLAGS="${CFLAGS:-} ${CFLAGS_WASM[*]}"
 export CPPFLAGS="${CPPFLAGS:-} -I$MERGED_SYSROOT/include -I$MERGED_SYSROOT/include/wasm32-wasi"
-export LDFLAGS="${LDFLAGS:-} ${LDFLAGS_WASM[*]}"
+export LDFLAGS="${LDFLAGS:-} ${LDFLAGS_CONFIGURE[*]}"
 
 # ----------------------------------------------------------------------
 # 4) autoreconf (generate configure from configure.ac)
@@ -113,10 +164,11 @@ autoreconf -fi
 # ----------------------------------------------------------------------
 echo "[curl] configuring…"
 
+# shellcheck disable=SC2086 # Intentionally splitting CONFIG_SHARED_FLAGS
 ./configure \
   --build="$(./config.guess)" \
   --host=wasm32-unknown-linux-gnu \
-  --disable-shared --enable-static --disable-libtool-lock \
+  $CONFIG_SHARED_FLAGS --disable-libtool-lock \
   --with-openssl --with-zlib \
   --without-libssh2 --without-libssh --without-brotli --without-zstd \
   --without-libpsl --without-nghttp2 --without-librtmp --without-gssapi \
@@ -134,7 +186,7 @@ echo "[curl] configuring…"
   RANLIB="$RANLIB" \
   CFLAGS="${CFLAGS_WASM[*]}" \
   CPPFLAGS="$CPPFLAGS" \
-  LDFLAGS="${LDFLAGS_WASM[*]}" \
+  LDFLAGS="${LDFLAGS_CONFIGURE[*]}" \
   LIBS="-lssl -lcrypto -lz" \
   PKG_CONFIG=false \
   curl_cv_writable_argv=yes
@@ -143,7 +195,11 @@ echo "[curl] configuring…"
 # 6) Build
 # ----------------------------------------------------------------------
 echo "[curl] building…"
-make -j"$JOBS" V=1
+
+# Inject the true Wasm LDFLAGS and CFLAGS for the make step
+make -j"$JOBS" V=1 \
+  CFLAGS="${CFLAGS_WASM[*]}" \
+  LDFLAGS="${LDFLAGS_WASM[*]}"
 
 # ----------------------------------------------------------------------
 # 7) Stage binary
@@ -169,37 +225,53 @@ CURL_OPT_WASM="$SCRIPT_DIR/curl.opt.wasm"
 cp "$CURL_BIN" "$CURL_WASM"
 
 # ----------------------------------------------------------------------
-# 8) wasm-opt (best-effort)
+# 8) wasm-opt & exports
 # ----------------------------------------------------------------------
 if [[ -x "$WASM_OPT" ]]; then
   echo "[curl] running wasm-opt (asyncify + optimization)…"
-  "$WASM_OPT" \
-    --epoch-injection \
-    --asyncify \
-    --debuginfo \
-    -O2 \
-    "$CURL_WASM" \
-    -o "$CURL_OPT_WASM" || true
+  if [[ "$LIND_DYLINK" == "1" ]]; then
+    "$WASM_OPT" \
+      --enable-bulk-memory --enable-threads \
+      --epoch-injection --pass-arg=epoch-import --pass-arg=epoch-main-module \
+      --asyncify --pass-arg=asyncify-import-globals \
+      --debuginfo \
+      "$CURL_WASM" -o "$CURL_OPT_WASM" || true
+  else
+    "$WASM_OPT" \
+      --epoch-injection \
+      --asyncify \
+      --debuginfo \
+      -O2 \
+      "$CURL_WASM" -o "$CURL_OPT_WASM" || true
+  fi
 else
-  echo "[curl] NOTE: wasm-opt not found at '$WASM_OPT'; skipping optimization. Exiting.."
+  echo "[curl] ERROR: wasm-opt not found at '$WASM_OPT'; skipping optimization. Exiting.."
   exit 1
 fi
 
 if [[ ! -f "$CURL_OPT_WASM" ]]; then
-  echo "[curl] ERROR: Failed to generate "$CURL_OPT_WASM"; Exiting.."
+  echo "[curl] ERROR: Failed to generate $CURL_OPT_WASM; Exiting.."
   exit 1
+fi
+
+# Add dylink exports if dynamic linking is enabled
+if [[ "$LIND_DYLINK" == "1" ]]; then
+  echo "[curl] adding dylink exports via add-export-tool..."
+  "$ADD_EXPORT_TOOL" "$CURL_OPT_WASM" "$CURL_OPT_WASM" __wasm_apply_tls_relocs func __wasm_apply_tls_relocs optional
+  "$ADD_EXPORT_TOOL" "$CURL_OPT_WASM" "$CURL_OPT_WASM" __wasm_apply_global_relocs func __wasm_apply_global_relocs optional
+  "$ADD_EXPORT_TOOL" "$CURL_OPT_WASM" "$CURL_OPT_WASM" __stack_pointer global __stack_pointer
 fi
 
 # ----------------------------------------------------------------------
 # 9) cwasm generation (best-effort) via lind-boot --precompile
 # ----------------------------------------------------------------------
 if [[ -x "$LIND_BOOT" ]]; then
-  echo "[git] generating cwasm via lind-boot --precompile..."
+  echo "[curl] generating cwasm via lind-boot --precompile..."
   if "$LIND_BOOT" --precompile "$CURL_OPT_WASM"; then
-  
+   
     CURL_OPT_CWASM="$SCRIPT_DIR/curl.opt.cwasm"
 
-    #Staging the final .cwasm binary to the build folder
+    # Stage the final .cwasm binary
     if [[ -f "$CURL_OPT_CWASM" ]]; then
       cp "$CURL_OPT_CWASM" "$STAGE_DIR/curl"
       echo "[curl] curl staged as $STAGE_DIR/curl"
@@ -209,12 +281,10 @@ if [[ -x "$LIND_BOOT" ]]; then
     fi
   else
     echo "[curl] ERROR: lind-boot --precompile failed; skipping cwasm generation."
-    echo "[curl] ERROR: No binaries copied to the build folder. Exiting.."
     exit 1
   fi
 else
   echo "[curl] ERROR: lind-boot not found at '$LIND_BOOT'; skipping cwasm generation."
-  echo "[curl] ERROR: No binaries copied to the build folder. Exiting.."
   exit 1
 fi
 

--- a/curl/compile_curl.sh
+++ b/curl/compile_curl.sh
@@ -234,15 +234,14 @@ if [[ -x "$WASM_OPT" ]]; then
       --enable-bulk-memory --enable-threads \
       --epoch-injection --pass-arg=epoch-import --pass-arg=epoch-main-module \
       --asyncify --pass-arg=asyncify-import-globals \
-      --debuginfo \
-      "$CURL_WASM" -o "$CURL_OPT_WASM" || true
+      -O2 --debuginfo \
+      "$CURL_WASM" -o "$CURL_OPT_WASM"
   else
     "$WASM_OPT" \
       --epoch-injection \
       --asyncify \
-      --debuginfo \
-      -O2 \
-      "$CURL_WASM" -o "$CURL_OPT_WASM" || true
+      -O2 --debuginfo \
+      "$CURL_WASM" -o "$CURL_OPT_WASM"
   fi
 else
   echo "[curl] ERROR: wasm-opt not found at '$WASM_OPT'; skipping optimization. Exiting.."

--- a/curl/run_tests.sh
+++ b/curl/run_tests.sh
@@ -26,7 +26,14 @@ if [[ -z "${LIND_WASM_ROOT:-}" ]]; then
     LIND_WASM_ROOT="$(cd "$APPS_ROOT/.." && pwd)"
 fi
 
-LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run --preload env=lib/libz.so --preload env=lib/libcrypto.so --preload env=lib/libssl.so"
+LIND_DYLINK="${LIND_DYLINK:-0}"
+
+if [[ "$LIND_DYLINK" == "1" ]]; then
+        LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run --preload env=lib/libz.so --preload env=lib/libcrypto.so --preload env=lib/libssl.so"
+else
+        LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run"
+fi
+
 LINDFS_ROOT="$LIND_WASM_ROOT/lindfs"
 CURL_BIN="usr/local/bin/curl"
 

--- a/curl/run_tests.sh
+++ b/curl/run_tests.sh
@@ -26,7 +26,7 @@ if [[ -z "${LIND_WASM_ROOT:-}" ]]; then
     LIND_WASM_ROOT="$(cd "$APPS_ROOT/.." && pwd)"
 fi
 
-LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run"
+LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run --preload env=lib/libz.so --preload env=lib/libcrypto.so --preload env=lib/libssl.so"
 LINDFS_ROOT="$LIND_WASM_ROOT/lindfs"
 CURL_BIN="usr/local/bin/curl"
 


### PR DESCRIPTION
Closes #100 
 Enable dynamic WebAssembly builds (LIND_DYLINK=1) for curl`

Shared libraries that `git` depends on:
- openssl (`libssl.so` and `libcrypto.so`)
- zlib (`libz.so`)
- libc

## Summary
This PR updates the `curl` build pipeline to support cross-compiling as a WebAssembly Position Independent Executable (PIE). When `LIND_DYLINK=1` is enabled, `curl` will be compiled to dynamically link its external dependencies (OpenSSL, zlib) at runtime via the `lind-wasm` environment, rather than statically linking them into the binary.

## Technical Details
Building Autotools/Libtool projects for WebAssembly dynamic linking requires bypassing several traditional Linux/ELF assumptions. This PR implements the "Static Internal, Dynamic External" workaround.

**1. Libtool / ELF Versioning Bypass**
* By default, passing `--enable-shared` to `curl`'s configure script causes Libtool to generate ELF version scripts (`.ver`), which WebAssembly's linker (`wasm-ld`) completely rejects.
* **Fix:** The script intentionally leaves `--disable-shared --enable-static` enabled for Libtool, but overrides the environment to force the compiler to use Position Independent Code (`-fPIC`). This causes `curl`'s internal libraries (`libcurl.la`) to compile safely as `.a` archives containing PIC objects, which are then successfully linked into the final dynamic executable.

**2. Linker Flag Splitting (`LDFLAGS`)**
* `autoconf` feature tests frequently fail if they encounter undefined symbols too early. 
* **Fix:** The script now uses two separate LDFLAGS arrays. `LDFLAGS_CONFIGURE` uses strict static linking rules so feature detection works cleanly. `LDFLAGS_WASM` (injected only during the `make` step) includes the necessary `-Wl,-pie`, `--allow-undefined`, and `--unresolved-symbols=import-dynamic` flags required to build the Wasm PIE.

**3. CRT & Export Handling**
* Includes required Lind-specific CRT objects (`set_stack_pointer.o`, `crt1_shared.o`).
* Modifies `wasm-opt` to support bulk memory and threads for dynamic environments.
* Runs `add-export-tool` immediately after optimization to expose `__wasm_apply_tls_relocs`, `__wasm_apply_global_relocs`, and `__stack_pointer` to the runtime host.

## Test Runner Updates
* **Runtime Preloading:** Updated the test execution wrapper. When `LIND_DYLINK=1`, the test suite now runs `lind_run` with the necessary `--preload env=...` arguments. This resolves the `unknown import` errors by ensuring the Wasm runtime populates the `env` namespace with our shared dependencies before executing `curl.cwasm`.

## How to Test
 **Test Static Path:**
  - `make curl`
  - `APP=curl make test`
  
 **Test Dynamic Path:**
  - `LIND_DYLINK=1 make curl`
   - `LIND_DYLINK=1 APP=curl make test`
   (This requires the updates from [this PR](https://github.com/Lind-Project/lind-wasm-apps/pull/185) which does dynamic compilation of libraries)
