### PR TITLE
Enable dynamic wasm build for git and update test runner

### DIFF
--- a/git/compile_git.sh
+++ b/git/compile_git.sh
@@ -265,11 +265,11 @@ if [[ -x "$WASM_OPT" ]]; then
       --enable-bulk-memory --enable-threads \
       --epoch-injection --pass-arg=epoch-import --pass-arg=epoch-main-module \
       --asyncify --pass-arg=asyncify-import-globals \
-      --debuginfo \
-      "$GIT_WASM" -o "$GIT_OPT_WASM" || true
+      -O2 --debuginfo \
+      "$GIT_WASM" -o "$GIT_OPT_WASM"
   else
-    "$WASM_OPT" --epoch-injection --asyncify --debuginfo -O2 \
-      "$GIT_WASM" -o "$GIT_OPT_WASM" || true
+    "$WASM_OPT" --epoch-injection --asyncify -O2 --debuginfo \
+      "$GIT_WASM" -o "$GIT_OPT_WASM"
   fi
 else
   echo "[git] NOTE: wasm-opt not found at '$WASM_OPT'; skipping optimization. Exiting.."

--- a/git/compile_git.sh
+++ b/git/compile_git.sh
@@ -13,6 +13,10 @@ set -euo pipefail
 #   5. Precompile with lind-boot
 #
 # Supports both Static (default) and Dynamic (LIND_DYLINK=1) builds.
+#
+# Prerequisites:
+#   - Run 'make preflight' and 'make merge-sysroot' from lind-wasm-apps root
+#   - Or run 'make all' to build everything including dependencies
 ###############################################################################
 
 # --- basic paths -------------------------------------------------------------

--- a/git/compile_git.sh
+++ b/git/compile_git.sh
@@ -12,9 +12,7 @@ set -euo pipefail
 #   4. Optimize with wasm-opt (asyncify)
 #   5. Precompile with lind-boot
 #
-# Prerequisites:
-#   - Run 'make preflight' and 'make merge-sysroot' from lind-wasm-apps root
-#   - Or run 'make all' to build everything including dependencies
+# Supports both Static (default) and Dynamic (LIND_DYLINK=1) builds.
 ###############################################################################
 
 # --- basic paths -------------------------------------------------------------
@@ -51,6 +49,7 @@ WASM_OPT="${WASM_OPT:-$LIND_WASM_ROOT/tools/binaryen/bin/wasm-opt}"
 LIND_BOOT="${LIND_BOOT:-$LIND_WASM_ROOT/build/lind-boot}"
 
 JOBS="${JOBS:-$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN || echo 4)}"
+LIND_DYLINK="${LIND_DYLINK:-0}"
 
 # Output location
 GIT_OUT_DIR="$APPS_ROOT/build/git/usr/local/bin"
@@ -74,14 +73,65 @@ fi
 
 CC_WASM="$CLANG --target=wasm32-unknown-wasi --sysroot=$MERGED_SYSROOT"
 
-CFLAGS_WASM="-O2 -g -pthread -matomics -mbulk-memory \
-  -I$MERGED_SYSROOT/include \
-  -I$MERGED_SYSROOT/include/wasm32-wasi"
+# Using arrays for flags to handle dynamic additions cleanly
+CFLAGS_WASM=(
+  -O2 -g -pthread -matomics -mbulk-memory
+  -I"$MERGED_SYSROOT/include"
+  -I"$MERGED_SYSROOT/include/wasm32-wasi"
+)
 
-LDFLAGS_WASM="-Wl,--import-memory,--export-memory,--max-memory=67108864 \
-  -Wl,--export=__stack_pointer,--export=__stack_low,--export=__tls_base,--shared-memory \
-  -L$MERGED_SYSROOT/lib/wasm32-wasi \
-  -L$MERGED_SYSROOT/usr/lib/wasm32-wasi"
+# ----------------------------------------------------------------------
+# Branch Logic: Dynamic vs Static Settings
+# ----------------------------------------------------------------------
+if [[ "$LIND_DYLINK" == "1" ]]; then
+  echo "[git] Mode: DYNAMIC LINKING (LIND_DYLINK=1)"
+  CFLAGS_WASM+=(-fPIC)
+
+  ADD_EXPORT_TOOL="$LIND_WASM_ROOT/tools/add-export-tool/add-export-tool"
+  if [[ ! -x "$ADD_EXPORT_TOOL" ]]; then
+    echo "[git] ERROR: add-export-tool not found at '$ADD_EXPORT_TOOL'" >&2
+    exit 1
+  fi
+
+  DYLINK_CRT_OBJS=(
+    "$MERGED_SYSROOT/lib/wasm32-wasi/set_stack_pointer.o"
+    "$MERGED_SYSROOT/lib/wasm32-wasi/crt1_shared.o"
+    "$MERGED_SYSROOT/lib/wasm32-wasi/lind_utils.o"
+  )
+  for obj in "${DYLINK_CRT_OBJS[@]}"; do
+    if [[ ! -f "$obj" ]]; then
+      echo "[git] ERROR: required dylink CRT object '$obj' not found." >&2
+      exit 1
+    fi
+  done
+
+  LDFLAGS_WASM=(
+    "-nostartfiles"
+    "-Wl,-pie"
+    "-Wl,--import-table"
+    "-Wl,--import-memory"
+    "-Wl,--export-memory"
+    "-Wl,--shared-memory"
+    "-Wl,--max-memory=67108864"
+    "-Wl,--allow-undefined"
+    "-Wl,--unresolved-symbols=import-dynamic"
+    "-Wl,--export=__wasm_call_ctors"
+    "-Wl,--export-if-defined=__wasm_init_tls"
+    "-Wl,--export=__tls_base"
+    -L"$MERGED_SYSROOT/lib/wasm32-wasi"
+    -L"$MERGED_SYSROOT/usr/lib/wasm32-wasi"
+    "${DYLINK_CRT_OBJS[@]}"
+  )
+else
+  echo "[git] Mode: STATIC LINKING (LIND_DYLINK=0 or unset)"
+  
+  LDFLAGS_WASM=(
+    "-Wl,--import-memory,--export-memory,--max-memory=67108864"
+    "-Wl,--export=__stack_pointer,--export=__stack_low,--export=__tls_base,--shared-memory"
+    -L"$MERGED_SYSROOT/lib/wasm32-wasi"
+    -L"$MERGED_SYSROOT/usr/lib/wasm32-wasi"
+  )
+fi
 
 echo "[git] using CLANG       = $CLANG"
 echo "[git] using AR          = $AR"
@@ -171,12 +221,13 @@ echo "[git] building git with wasm32-wasi toolchain..."
 # Git's Makefile accepts all configuration via variables — no autoconf needed.
 # We disable features that require libraries or runtimes unavailable in WASI.
 # config.mak (generated above) handles Linux-specific overrides.
+# Injecting our constructed CFLAGS and LDFLAGS arrays here.
 make -j"$JOBS" \
   CC="$CC_WASM" \
   AR="$AR" \
   RANLIB="$RANLIB" \
-  CFLAGS="$CFLAGS_WASM" \
-  LDFLAGS="$LDFLAGS_WASM" \
+  CFLAGS="${CFLAGS_WASM[*]}" \
+  LDFLAGS="${LDFLAGS_WASM[*]}" \
   NO_CURL=1 \
   NO_ICONV=1 \
   NO_EXPAT=1 \
@@ -204,22 +255,38 @@ GIT_OPT_WASM="$SCRIPT_DIR/git.opt.wasm"
 cp git "$GIT_WASM"
 
 ###############################################################################
-# 4. wasm-opt (best-effort)
+# 4. wasm-opt & exports
 ###############################################################################
-
 
 if [[ -x "$WASM_OPT" ]]; then
   echo "[git] running wasm-opt (asyncify + optimization)..."
-  "$WASM_OPT" --epoch-injection --asyncify --debuginfo -O2 \
-    "$GIT_WASM" -o "$GIT_OPT_WASM"
+  if [[ "$LIND_DYLINK" == "1" ]]; then
+    "$WASM_OPT" \
+      --enable-bulk-memory --enable-threads \
+      --epoch-injection --pass-arg=epoch-import --pass-arg=epoch-main-module \
+      --asyncify --pass-arg=asyncify-import-globals \
+      --debuginfo \
+      "$GIT_WASM" -o "$GIT_OPT_WASM" || true
+  else
+    "$WASM_OPT" --epoch-injection --asyncify --debuginfo -O2 \
+      "$GIT_WASM" -o "$GIT_OPT_WASM" || true
+  fi
 else
   echo "[git] NOTE: wasm-opt not found at '$WASM_OPT'; skipping optimization. Exiting.."
   exit 1
 fi
 
 if [[ ! -f "$GIT_OPT_WASM" ]]; then
-  echo "[git] ERROR: Failed to generate "$GIT_OPT_WASM"; Exiting.."
+  echo "[git] ERROR: Failed to generate $GIT_OPT_WASM; Exiting.."
   exit 1
+fi
+
+# Add dylink exports if dynamic linking is enabled
+if [[ "$LIND_DYLINK" == "1" ]]; then
+  echo "[git] adding dylink exports via add-export-tool..."
+  "$ADD_EXPORT_TOOL" "$GIT_OPT_WASM" "$GIT_OPT_WASM" __wasm_apply_tls_relocs func __wasm_apply_tls_relocs optional
+  "$ADD_EXPORT_TOOL" "$GIT_OPT_WASM" "$GIT_OPT_WASM" __wasm_apply_global_relocs func __wasm_apply_global_relocs optional
+  "$ADD_EXPORT_TOOL" "$GIT_OPT_WASM" "$GIT_OPT_WASM" __stack_pointer global __stack_pointer
 fi
 
 ###############################################################################

--- a/git/run_tests.sh
+++ b/git/run_tests.sh
@@ -26,7 +26,14 @@ if [[ -z "${LIND_WASM_ROOT:-}" ]]; then
     LIND_WASM_ROOT="$(cd "$APPS_ROOT/.." && pwd)"
 fi
 
-LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run"
+LIND_DYLINK="${LIND_DYLINK:-0}"
+
+if [[ "$LIND_DYLINK" == "1" ]]; then
+        LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run --preload env=lib/libz.so --preload env=lib/libcrypto.so --preload env=lib/libssl.so"
+else
+        LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run"
+fi
+
 LINDFS_ROOT="$LIND_WASM_ROOT/lindfs"
 GIT_BIN="usr/local/bin/git"
 REPO_PATH="/tmp/git-test-repo"

--- a/git/run_tests.sh
+++ b/git/run_tests.sh
@@ -28,10 +28,11 @@ fi
 
 LIND_DYLINK="${LIND_DYLINK:-0}"
 
+LIND_RUN=("$LIND_WASM_ROOT/scripts/lind_run")
 if [[ "$LIND_DYLINK" == "1" ]]; then
-        LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run --preload env=lib/libz.so --preload env=lib/libcrypto.so --preload env=lib/libssl.so"
-else
-        LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run"
+    # Dynamic builds need shared libs preloaded into the wasm env namespace.
+    # These paths are relative to lindfs (installed by make install).
+    LIND_RUN+=(--preload env=lib/libz.so --preload env=lib/libcrypto.so --preload env=lib/libssl.so)
 fi
 
 LINDFS_ROOT="$LIND_WASM_ROOT/lindfs"
@@ -99,12 +100,12 @@ run_test() {
 
 # Helper to run git inside the test repo
 run_git() {
-    $LIND_RUN "$GIT_BIN" -C "$REPO_PATH" "$@" 2>&1
+    "${LIND_RUN[@]}" "$GIT_BIN" -C "$REPO_PATH" "$@" 2>&1
 }
 
 # Helper to run git inside the cloned repo
 run_git_clone() {
-    $LIND_RUN "$GIT_BIN" -C "$CLONE_PATH" "$@" 2>&1
+    "${LIND_RUN[@]}" "$GIT_BIN" -C "$CLONE_PATH" "$@" 2>&1
 }
 
 # --- test cases --------------------------------------------------------------
@@ -117,21 +118,21 @@ test_binary_exists() {
 # 2. --version
 test_version() {
     local output
-    output=$($LIND_RUN "$GIT_BIN" --version 2>&1)
+    output=$("${LIND_RUN[@]}" "$GIT_BIN" --version 2>&1)
     [[ "$output" == *"git version"* ]]
 }
 
 # 3. --help
 test_help() {
     local output
-    output=$($LIND_RUN "$GIT_BIN" --help 2>&1)
+    output=$("${LIND_RUN[@]}" "$GIT_BIN" --help 2>&1)
     echo "$output" | grep -qi "usage"
 }
 
 # 4. git init
 test_init() {
     local output
-    output=$($LIND_RUN "$GIT_BIN" init "$REPO_PATH" 2>&1)
+    output=$("${LIND_RUN[@]}" "$GIT_BIN" init "$REPO_PATH" 2>&1)
     [[ "$output" == *"Initialized empty Git repository"* ]]
 }
 
@@ -381,7 +382,7 @@ test_clone_bare() {
 
     # Verify the bare repo is usable inside Lind
     local output
-    output=$($LIND_RUN "$GIT_BIN" -C "$REMOTE_PATH" log --oneline 2>&1)
+    output=$("${LIND_RUN[@]}" "$GIT_BIN" -C "$REMOTE_PATH" log --oneline 2>&1)
     [[ "$output" == *"first commit"* ]]
 }
 
@@ -390,7 +391,7 @@ test_clone() {
     # Transport (clone/fetch) forks and panics in Lind.  We init a fresh
     # repo, copy objects + refs from the bare remote on the host side, then
     # let git checkout the working tree inside Lind.
-    $LIND_RUN "$GIT_BIN" init "$CLONE_PATH" 2>&1 >/dev/null || true
+    "${LIND_RUN[@]}" "$GIT_BIN" init "$CLONE_PATH" 2>&1 >/dev/null || true
     run_git_clone remote add origin "$REMOTE_PATH"
 
     # Copy objects
@@ -446,7 +447,7 @@ test_push() {
 
     # Verify the bare remote now contains the pushed commit
     local output
-    output=$($LIND_RUN "$GIT_BIN" -C "$REMOTE_PATH" log --oneline 2>&1)
+    output=$("${LIND_RUN[@]}" "$GIT_BIN" -C "$REMOTE_PATH" log --oneline 2>&1)
     [[ "$output" == *"push test commit"* ]]
 }
 


### PR DESCRIPTION
Closes #101 
This PR introduces the ability to compile `git` as a Position Independent Executable (PIE) that dynamically links its dependencies at runtime in the `lind-wasm` environment. It also updates our test harness to successfully execute these dynamic builds by preloading the required shared libraries.

Shared libraries that `git` depends on:
- openssl (`libssl.so` and `libcrypto.so`)
- zlib (`libz.so`)
- libc

## 1. Build Script Updates (`git`)
* **Compiler Flags:** Conditionally injects `-fPIC` into `CFLAGS`.
* **Linker Flags:** Splits standard static linking from dynamic linking. Dynamic builds now include `-Wl,-pie`, `-Wl,--shared-memory`, and `--unresolved-symbols=import-dynamic`.
* **CRT Objects:** Ensures the required Lind objects (`set_stack_pointer.o`, `crt1_shared.o`, `lind_utils.o`) are linked into the dynamic executable.
* **Wasm Optimization:** Branches `wasm-opt` to include `--enable-bulk-memory` and `--enable-threads`, followed by `add-export-tool` to explicitly expose relocation and stack pointer symbols to the host environment.

## Test Runner Updates
* **Runtime Preloading:** Updated the test execution wrapper. When `LIND_DYLINK=1`, the test suite now runs `lind_run` with the necessary `--preload env=...` arguments. This resolves the `unknown import` errors by ensuring the Wasm runtime populates the `env` namespace with our shared dependencies before executing `git.cwasm`.

## How to Test
 **Test Static Path:**
  - `make git`
  - `APP= git make test`
  
 **Test Dynamic Path:**
  - `LIND_DYLINK=1 make git `
   - `LIND_DYLINK=1 APP= git make test`
   (This requires the updates from [this PR](https://github.com/Lind-Project/lind-wasm-apps/pull/185) which does dynamic compilation of libraries)
