### PR TITLE
modifed gcc compile script so that it copies over the headerfiles fro…

### DIFF
--- a/gcc/compile_gcc.sh
+++ b/gcc/compile_gcc.sh
@@ -409,3 +409,31 @@ echo
 echo "[gcc] build complete. Outputs under:"
 echo "  $STAGE_DIR"
 ls -lh "$STAGE_DIR" || true
+
+# ----------------------------------------------------------------------
+# 10) Stage headers and libc files for lindfs
+# ----------------------------------------------------------------------
+HOST_GCC_VER=$(gcc -dumpversion | cut -d. -f1)
+TARGET_GCC_VER="15.2.0"
+TARGET_TRIPLET="x86_64-linux-gnu"
+
+INCLUDE_DST="$APPS_BUILD/gcc/usr/include"
+LIB_DST="$APPS_BUILD/gcc/usr/lib/$TARGET_TRIPLET"
+LIB64_DST="$APPS_BUILD/gcc/lib/$TARGET_TRIPLET"
+GCC_INCLUDE_DST="$APPS_BUILD/gcc/usr/local/lib/gcc/$TARGET_TRIPLET/$TARGET_GCC_VER/include"
+LINKER_DST="$APPS_BUILD/gcc/lib64"
+
+mkdir -p "$INCLUDE_DST" "$LIB_DST" "$LIB64_DST" "$GCC_INCLUDE_DST" "$LINKER_DST"
+
+echo "[gcc] staging headers and libc files..."
+cp -r /usr/include/. "$INCLUDE_DST/"
+cp -r /usr/include/$TARGET_TRIPLET/. "$INCLUDE_DST/"
+cp /usr/lib/gcc/$TARGET_TRIPLET/$HOST_GCC_VER/include/*.h "$GCC_INCLUDE_DST/"
+cp /usr/lib/$TARGET_TRIPLET/crt1.o /usr/lib/$TARGET_TRIPLET/crti.o \
+   /usr/lib/$TARGET_TRIPLET/crtn.o /usr/lib/$TARGET_TRIPLET/libc_nonshared.a \
+   /usr/lib/$TARGET_TRIPLET/libc.so "$LIB_DST/"
+cp /usr/lib/$TARGET_TRIPLET/libm* "$LIB_DST/"
+cp /lib/$TARGET_TRIPLET/libc.so.6 /lib/$TARGET_TRIPLET/libm.so.6 \
+   /lib/$TARGET_TRIPLET/libmvec* "$LIB64_DST/"
+cp /lib64/ld-linux-x86-64.so.2 "$LINKER_DST/"
+echo "[gcc] headers and libc staged"


### PR DESCRIPTION
## Summary
Gets GCC (cc1 + as + ld) fully working inside the Lind sandbox by staging the necessary host headers and libc files into lindfs during the compile step.

## Changes
- Added step 10 to `gcc/compile_gcc.sh` that stages x86_64-linux-gnu headers and libs into `build/gcc/` so `post_install.sh`'s rsync picks them up automatically on `make install-gcc`

## What gets staged
- `/usr/include` + `/usr/include/x86_64-linux-gnu` → `usr/include/` in lindfs
- GCC internal headers (stddef.h, stdarg.h, etc.) → `usr/local/lib/gcc/x86_64-linux-gnu/15.2.0/include/`
- `crt1.o`, `crti.o`, `crtn.o`, `libc.so`, `libc_nonshared.a`, `libm*` → `usr/lib/x86_64-linux-gnu/`
- `libc.so.6`, `libm.so.6`, `libmvec*` → `lib/x86_64-linux-gnu/`
- `ld-linux-x86-64.so.2` → `lib64/`

## Testing
Full cc1 → as → ld pipeline verified with:

**hello world** (`int main() { return 0; }`) — clean compile, no errors

**stdio + string + math:**
```c
#include <stdio.h>
#include <string.h>
#include <math.h>int main() {
char msg[] = "Hello from Lind!";
int len = strlen(msg);
double root = sqrt(144.0);
printf("%s (len=%d, sqrt(144)=%.0f)\n", msg, len, root);
return 0;
}
```
Output:
Hello from Lind! (len=16, sqrt(144)=12)
## Notes
- gcc was built with `--without-headers` so headers are sourced from the host (`libc6-dev` must be installed)
- The staged ELF output runs natively on the host — lind-boot cannot execute ELF directly
- `sudo chown -R lind:lind ~/lind-wasm/lindfs` may be needed after `make install-gcc` if rsync hits permission errors
