### PR TITLE
Remove set_stack_pointer.o references from app compile scripts

### DIFF
--- a/bash/compile_bash.sh
+++ b/bash/compile_bash.sh
@@ -58,7 +58,7 @@ FORCE_CONFIGURE="${FORCE_CONFIGURE:-0}"
 # LIND_DYLINK controls whether we produce a statically-linked or a shared
 # (PIE/dynamic) wasm binary.  Set LIND_DYLINK=1 to get the shared path;
 # the default is static (0).  The shared path adds the PIE linker flags, links
-# in lind_debug.o and set_stack_pointer.o, runs add-export-tool to inject the
+# in lind_debug.o, runs add-export-tool to inject the
 # __wasm_apply_* and __stack_pointer exports, and uses the additional wasm-opt
 # passes required for shared modules.
 ##################
@@ -120,7 +120,6 @@ if [[ "$LIND_DYLINK" == "1" ]]; then
 
   # lind_debug.o lives in the glibc build tree (not installed to the sysroot)
   DYLINK_CRT_OBJS=(
-    "$LIND_WASM_ROOT/src/glibc/build/csu/set_stack_pointer.o"
     "$LIND_WASM_ROOT/src/glibc/build/lind_debug.o"
   )
   for obj in "${DYLINK_CRT_OBJS[@]}"; do

--- a/coreutils/compile_coreutils.sh
+++ b/coreutils/compile_coreutils.sh
@@ -107,7 +107,6 @@ if [[ "$LIND_DYLINK" == "1" ]]; then
 
   # Extra CRT objects required for dynamic PIE executables
   DYLINK_CRT_OBJS=(
-    "$MERGED_SYSROOT/lib/wasm32-wasi/set_stack_pointer.o"
     "$MERGED_SYSROOT/lib/wasm32-wasi/crt1_shared.o"
     "$MERGED_SYSROOT/lib/wasm32-wasi/lind_utils.o"
   )

--- a/cpython/compile_cpython.sh
+++ b/cpython/compile_cpython.sh
@@ -294,7 +294,6 @@ if [[ "$LIND_DYLINK" == "1" ]]; then
     "$BUILD_WASM/Modules/_decimal/libmpdec/libmpdec.a" \
     "$BUILD_WASM/Modules/_hacl/libHacl_HMAC.a" \
     "$BUILD_WASM/Modules/_hacl/libHacl_Hash_SHA3.a" \
-    "$SYSROOT/lib/wasm32-wasi/set_stack_pointer.o" \
     "$SYSROOT/lib/wasm32-wasi/crt1_shared.o" \
     "$SYSROOT/lib/wasm32-wasi/lind_utils.o" \
     -ldl -lwasi-emulated-signal -lwasi-emulated-getpid -lwasi-emulated-process-clocks -lpthread -lm

--- a/curl/compile_curl.sh
+++ b/curl/compile_curl.sh
@@ -82,7 +82,6 @@ if [[ "$LIND_DYLINK" == "1" ]]; then
   fi
 
   DYLINK_CRT_OBJS=(
-    "$MERGED_SYSROOT/lib/wasm32-wasi/set_stack_pointer.o"
     "$MERGED_SYSROOT/lib/wasm32-wasi/crt1_shared.o"
     "$MERGED_SYSROOT/lib/wasm32-wasi/lind_utils.o"
   )

--- a/git/compile_git.sh
+++ b/git/compile_git.sh
@@ -98,7 +98,6 @@ if [[ "$LIND_DYLINK" == "1" ]]; then
   fi
 
   DYLINK_CRT_OBJS=(
-    "$MERGED_SYSROOT/lib/wasm32-wasi/set_stack_pointer.o"
     "$MERGED_SYSROOT/lib/wasm32-wasi/crt1_shared.o"
     "$MERGED_SYSROOT/lib/wasm32-wasi/lind_utils.o"
   )

--- a/grep/compile_grep.sh
+++ b/grep/compile_grep.sh
@@ -82,7 +82,6 @@ if [[ "$LIND_DYLINK" == "1" ]]; then
   fi
 
   DYLINK_CRT_OBJS=(
-    "$MERGED_SYSROOT/lib/wasm32-wasi/set_stack_pointer.o"
     "$MERGED_SYSROOT/lib/wasm32-wasi/crt1_shared.o"
     "$MERGED_SYSROOT/lib/wasm32-wasi/lind_utils.o"
   )

--- a/lmbench/src/compile_lmbench.sh
+++ b/lmbench/src/compile_lmbench.sh
@@ -209,7 +209,6 @@ if [[ "$LIND_DYLINK" == "1" ]]; then
   fi
   # Extra objects required for dynamic PIE executables
   DYLINK_CRT_OBJS=(
-    "$MERGED_SYSROOT/lib/wasm32-wasi/set_stack_pointer.o"
     "$MERGED_SYSROOT/lib/wasm32-wasi/crt1_shared.o"
     "$MERGED_SYSROOT/lib/wasm32-wasi/lind_utils.o"
   )

--- a/nginx/compile_nginx.sh
+++ b/nginx/compile_nginx.sh
@@ -126,7 +126,6 @@ if [[ "$LIND_DYLINK" == "1" ]]; then
 
     # Extra CRT objects required for dynamic PIE executables
     DYLINK_CRT_OBJS=(
-        "$MERGED_SYSROOT/lib/wasm32-wasi/set_stack_pointer.o"
         "$MERGED_SYSROOT/lib/wasm32-wasi/crt1_shared.o"
         "$MERGED_SYSROOT/lib/wasm32-wasi/lind_utils.o"
     )

--- a/postgres/compile_postgres.sh
+++ b/postgres/compile_postgres.sh
@@ -121,7 +121,6 @@ if [[ "$LIND_DYLINK" == "1" ]]; then
 
   # Extra CRT objects required for dynamic PIE executables
   DYLINK_CRT_OBJS=(
-    "$MERGED_SYSROOT/lib/wasm32-wasi/set_stack_pointer.o"
     "$MERGED_SYSROOT/lib/wasm32-wasi/crt1_shared.o"
     "$MERGED_SYSROOT/lib/wasm32-wasi/lind_utils.o"
   )


### PR DESCRIPTION
## Purpose

This PR removes remaining references to `set_stack_pointer.o` from application compile scripts in `lind-wasm-apps`.

This is a companion PR to the `lind-wasm` change for deprecating `set_stack_pointer.o`: https://github.com/Lind-Project/lind-wasm/pull/1120. After `set_stack_pointer.o` is removed from the sysroot/build outputs, app-side dynamic linking scripts should no longer require or link this object.

**Both PR should be merged together to make sure nothing is breaking**

## Changes

- Removed `set_stack_pointer.o` from dynamic linking CRT object lists in app compile scripts.
- Updated the bash dynamic linking comment to no longer mention `set_stack_pointer.o`.

## Related Issue / PR

Related to Lind-Project/lind-wasm issue: `glibc: depreciate set_stack_pointer.o #978`

Companion PR for the corresponding `lind-wasm` change.

## Validation

- Searched for remaining `set_stack_pointer.o` references in app compile scripts.
- Confirmed no remaining app-side references to `set_stack_pointer.o`.