### PR TITLE
Update prefix and add make install to perl compile

### DIFF
--- a/perl/compile_perl.sh
+++ b/perl/compile_perl.sh
@@ -159,12 +159,15 @@ echo "[perl] building..."
 make -j"$JOBS" || {
   echo "[perl] WARNING: build had errors (best-effort, continuing)."
 }
-make install DESTDIR="$APPS_BUILD/perl"
+
 PERL_BIN="$PERL_ROOT/perl"
 if [[ ! -f "$PERL_BIN" ]]; then
   echo "[perl] ERROR: perl binary not produced." >&2
   exit 1
 fi
+
+echo "[perl] installing to staging dir..."
+make install DESTDIR="$APPS_BUILD/perl"
 
 ###############################################################################
 # wasm-opt + precompile

--- a/perl/compile_perl.sh
+++ b/perl/compile_perl.sh
@@ -104,7 +104,7 @@ AR="$AR" \
 RANLIB="$RANLIB" \
 ./configure \
   --target=wasm32-unknown-wasi \
-  --prefix=/usr/local \
+  --prefix="/" \
   -Dcc="$CC_WASM" \
   -Dld="$CC_WASM" \
   -Dar="$AR" \
@@ -159,7 +159,7 @@ echo "[perl] building..."
 make -j"$JOBS" || {
   echo "[perl] WARNING: build had errors (best-effort, continuing)."
 }
-
+make install DESTDIR="$APPS_BUILD/perl"
 PERL_BIN="$PERL_ROOT/perl"
 if [[ ! -f "$PERL_BIN" ]]; then
   echo "[perl] ERROR: perl binary not produced." >&2


### PR DESCRIPTION
This PR is aimed at completing the perl installation
- Update `--prefix` to / while running `configure`. This folder determines the destination of where installed binaries and libraries as placed. And also, the path to search while running perl.
- `make install DESTDIR=$dir`
     This determines where installed binaries and libraries are placed.

So combining both gives the following:
- When you do `make install`, the final folder is determined by concatenating DESTDIR and prefix
- The default paths while running perl would be set relative to `prefix` path. 