### PR TITLE
fixed binary name mistmatch

### DIFF
--- a/coreutils/run_default_tests.sh
+++ b/coreutils/run_default_tests.sh
@@ -21,6 +21,7 @@ file="$LINDFS_TESTS/test-lib.sh"
 sed -i 's|"$abs_top_builddir/src/mktemp"|bin/mktemp|g' "$file"
 sed -i 's|^test_dir_=\$(pwd)|test_dir_=/tmp|' "$LINDFS_TESTS/test-lib.sh"
 sed -i "s|my \$cwd = \$@ ? '\.' : Cwd::getcwd();|my \$cwd = '/tmp';|" "$LINDFS_TESTS/CuTmpdir.pm"
+sed -i 's|my \$subst_expr = \$expect->{RESULT_SUBST}->{$eo};|my $subst_expr = $expect->{RESULT_SUBST}->{$eo};\n          if ($eo eq '"'"'ERR'"'"' \&\& !defined $subst_expr)\n          {\n              $subst_expr = '"'"'s\|`\/bin\/([^`]+)\|`$1\|g; s\|^\/bin\/([^\/:]+):\|$1:\|g'"'"';\n            }|' "$LINDFS_TESTS/Coreutils.pm"
 find "$LINDFS_TESTS" -type f -executable ! -name "*.pm" ! -name "*.pl" -exec sed -i 's|\$abs_top_builddir/src/|/bin/|g' {} +
 # =========================================================
 # ARGUMENT PARSING


### PR DESCRIPTION
# Description
Perl and other GNU scripts expects binary names to be just its name without any bin directory added
ex)
```
Executing: du/files0-from
Sandbox Path: /tests/du/files0-from
===================================================
files0-from: test f-extra-arg: stderr mismatch, comparing f-extra-arg.E (actual) and f-extra-arg.2 (expected)
*** f-extra-arg.E   Thu Jan  1 00:00:00 1970
--- f-extra-arg.2   Thu Jan  1 00:00:00 1970
***************
*** 1,3 ****
! /bin/du: extra operand `no-such'
  file operands cannot be combined with --files0-from
! Try `/bin/du --help' for more information.
--- 1,3 ----
! du: extra operand `no-such'
  file operands cannot be combined with --files0-from
```

The edit changes our current output of /bin/du to du so it matches the test case

```
===================================================
                  TEST SUMMARY                     
===================================================
 [PASS] : 36
 [FAIL] : 16
 [SKIP] : 353
===================================================
```
### FYI one of the test is failing because its missing perl's expect package 
Should be fixed by 
#234 