### PR TITLE
perl: drop unused IO::File import from IO-Tty Makefile.PL

### DIFF
--- a/perl/cpan/IO-Tty/Makefile.PL
+++ b/perl/cpan/IO-Tty/Makefile.PL
@@ -9,7 +9,8 @@ if ( $^O eq 'MSWin32' ) {
 use strict;
 use warnings;
 
-use IO::File;
+# IO::File removed: not used by this script and not on perl-cross's
+# bootstrap @INC, which makes Makefile.PL fail under miniperl.
 use File::Spec;
 use Config qw(%Config);
 


### PR DESCRIPTION
miniperl_top's bootstrap @INC doesn't include dist/IO/lib, so Makefile.PL dies on 'use IO::File' before reaching the cross-compile probes.  IO::File is imported but never actually used by this Makefile.PL, so removing the import lets perl-cross run it.