### PR TITLE
coreutils: forward host env vars into the lind cage for perl tests

### DIFF
--- a/coreutils/run_default_tests.sh
+++ b/coreutils/run_default_tests.sh
@@ -128,9 +128,15 @@ export CONFIG_HEADER="/lib/config.h"
 export TMPDIR="/tmp"
 export abs_top_builddir="/"
 export abs_top_srcdir="/"
+export abs_srcdir="/tests"
 export PATH="/bin:/usr/local/bin:/usr/bin"
 export srcdir="/tests"
 export srcdir="/home/lind/lind-wasm/lindfs/tests"
+
+# lind-boot does not auto-inherit the host environment into the cage; the guest
+# environ is built only from --env flags. Forward the vars perl tests read.
+ENV_FORWARD=(--env abs_top_builddir --env abs_top_srcdir --env abs_srcdir
+             --env PATH --env CONFIG_HEADER --env TMPDIR --env built_programs)
 
 # Tracking variables for the summary
 TOTAL_PASS=0; TOTAL_FAIL=0; TOTAL_SKIP=0
@@ -163,9 +169,9 @@ for CURRENT_TEST in "${TESTS_TO_RUN[@]}"; do
         
         T_BASE=$(basename "$CURRENT_TEST")
 	if [[ ${#GRATE_CMD[@]} -gt 0 ]]; then	
-		CMD=(lind_run --enable-fpcast "${GRATE_CMD[@]}" usr/local/bin/perl -w -I/lib -I/tests -MCoreutils -M"CuTmpdir qw($T_BASE)" -- "$SANDBOX_PATH")
+		CMD=(lind_run --enable-fpcast "${ENV_FORWARD[@]}" "${GRATE_CMD[@]}" usr/local/bin/perl -w -I/lib -I/tests -MCoreutils -M"CuTmpdir qw($T_BASE)" -- "$SANDBOX_PATH")
         else
-		CMD=(lind_run --enable-fpcast usr/local/bin/perl -w -I/lib -I/tests -MCoreutils -M"CuTmpdir qw($T_BASE)" -- "$SANDBOX_PATH")
+		CMD=(lind_run --enable-fpcast "${ENV_FORWARD[@]}" usr/local/bin/perl -w -I/lib -I/tests -MCoreutils -M"CuTmpdir qw($T_BASE)" -- "$SANDBOX_PATH")
 	fi
 else
         if [[ "$SKIP_BASH" -eq 1 ]]; then

--- a/coreutils/run_default_tests.sh
+++ b/coreutils/run_default_tests.sh
@@ -182,9 +182,9 @@ else
 
         sed -i 's/$srcdir/tests/g' "$HOST_TEST_PATH"
    	if [[ ${#GRATE_CMD[@]} -gt 0 ]]; then
-		CMD=(lind-wasm --enable-fpcast "${GRATE_CMD[@]}" bin/bash "$SANDBOX_PATH")
+		CMD=(lind-wasm --enable-fpcast "${ENV_FORWARD[@]}" "${GRATE_CMD[@]}" bin/bash "$SANDBOX_PATH")
 	else
-		CMD=(lind-wasm --enable-fpcast bin/bash "$SANDBOX_PATH")
+		CMD=(lind-wasm --enable-fpcast "${ENV_FORWARD[@]}" bin/bash "$SANDBOX_PATH")
 	fi	
    fi
 


### PR DESCRIPTION
lind-boot only populates the guest environ from --env flags; it does not auto-inherit the host environment. The previous CMD invocations passed no --env flags, so the abs_top_builddir / srcdir / PATH / etc. exports above never reached the perl test driver. misc/test-diag failed with "Use of uninitialized value $ENV{abs_top_builddir}" and pr/pr-tests with the same on $ENV{abs_srcdir}.

- Add the missing abs_srcdir export (only abs_top_srcdir was set).
- Add an ENV_FORWARD array of --env flags and inject it into both perl CMD branches (with and without GRATE_CMD).