### PR TITLE
ensure postgres related cwasms are executable

### DIFF
--- a/postgres/compile_postgres.sh
+++ b/postgres/compile_postgres.sh
@@ -1001,6 +1001,10 @@ for bin_name in "${STAGED_BINARIES[@]}"; do
         if [[ "$OPT_CWASM" != "$CLEAN_CWASM" && -f "$OPT_CWASM" ]]; then
           mv "$OPT_CWASM" "$CLEAN_CWASM"
         fi
+        # Ensure cwasm is executable
+        if [[ -f "$CLEAN_CWASM" ]]; then
+          chmod +x "$CLEAN_CWASM"
+        fi
       else
         echo "[postgres] WARNING: lind-boot --precompile failed for ${bin_name}."
       fi


### PR DESCRIPTION
Without this change, manual chmod has to be executed before running postgres installation. Permissions should be set by the build script.