### PR TITLE
Decouple tinycc build from full sysroot merge and fix tcc wasm-opt lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,7 @@ postgres: $(MERGE_BASE_STAMP) diffutils
 	'$(APPS_ROOT)/postgres/compile_postgres.sh'
 
 # ---------------- tinycc (WASM build) --------------------------------------
-tinycc: merge-sysroot
+tinycc: 
 	'$(APPS_ROOT)/tinycc/compile_tinycc.sh'
 
 # ---------------- diffutils (WASM build) --------------------------------------

--- a/tinycc/.gitignore
+++ b/tinycc/.gitignore
@@ -68,3 +68,5 @@ tests/vla_test
 tests/hello
 tests/tests2/fred.txt
 libtcc.dylib
+
+tcc_headers/

--- a/tinycc/compile_tinycc.sh
+++ b/tinycc/compile_tinycc.sh
@@ -24,9 +24,9 @@ MERGED_SYSROOT="$APPS_BUILD/sysroot_merged"
 STAGE_DIR="$APPS_BUILD/tinycc"
 TOOL_ENV="$APPS_BUILD/.toolchain.env"
 
-# Default LIND_WASM_ROOT to parent directory (layout: lind-wasm/lind-wasm-apps)
+# Default LIND_WASM_ROOT to parent directory (layout: lind-wasm-apps is parallel to lind-wasm)
 if [[ -z "${LIND_WASM_ROOT:-}" ]]; then
-  LIND_WASM_ROOT="$(cd "$APPS_ROOT/.." && pwd)"
+  LIND_WASM_ROOT="$(cd "$APPS_ROOT/../lind-wasm" && pwd)"
 fi
 
 WASM_OPT="${WASM_OPT:-$LIND_WASM_ROOT/tools/binaryen/bin/wasm-opt}"


### PR DESCRIPTION
## Summary

This PR updates the TinyCC build path in two places:

1. The top-level `Makefile` no longer requires the full merged sysroot dependency set before building `tinycc`.
2. `tinycc/compile_tinycc.sh` now resolves the `wasm-opt` path correctly under the current repo layout, where `lind-wasm-apps` may live next to `lind-wasm` instead of inside it.

## Motivation

The previous `tinycc` target depended on `merge-sysroot`, which pulls in all merge stamps, including dependencies that are not required for building TCC itself. For TinyCC, the build only needs the base sysroot/toolchain setup, not the app repo's additional library dependencies such as libtirpc, gnulib, zlib, openssl, libc++, or ed25519.

This made `make tinycc` unnecessarily expensive and fragile, since failures in unrelated library merge steps could block a TinyCC-only build.

In addition, the TinyCC compile script assumed the old repository layout:

```text
lind-wasm/
|--lind-wasm-apps/
```

Under the newer parallel layout:

```sh
lind-wasm/
lind-wasm-apps/
```

the previous wasm-opt lookup could point to the wrong location.

## Changes

1. Update the top-level Makefile so the tinycc target no longer depends on the full merge-sysroot target.
2. Update tinycc/compile_tinycc.sh to locate wasm-opt correctly with the current default repo layout.