### PR TITLE
Compile bash with EH-based setjmp/longjmp

### DIFF
--- a/bash/compile_bash.sh
+++ b/bash/compile_bash.sh
@@ -40,6 +40,7 @@ LLVM_BIN_DIR="$(dirname "$CLANG")"
 AR="${AR:-"$LLVM_BIN_DIR/llvm-ar"}"
 RANLIB="${RANLIB:-"$LLVM_BIN_DIR/llvm-ranlib"}"
 
+WASM_OPT="${WASM_OPT:-$LIND_WASM_ROOT/tools/binaryen/bin/wasm-opt}"
 LIND_WASM_OPT="${LIND_WASM_OPT:-$LIND_WASM_ROOT/scripts/lind-wasm-opt}"
 LIND_BOOT="${LIND_BOOT:-$LIND_WASM_ROOT/build/lind-boot}"
 ADD_EXPORT_TOOL="${ADD_EXPORT_TOOL:-$LIND_WASM_ROOT/tools/add-export-tool/add-export-tool}"
@@ -548,8 +549,13 @@ fi
 # output for debugging as `bash.raw.wasm`, but write the runnable module to the
 # traditional `bash.wasm` path. Full mode still adds the extra alias and cwasm.
 ##################
-if [[ ! -x "$LIND_WASM_OPT" ]]; then
-  echo "[bash] ERROR: lind-wasm-opt not found at '$LIND_WASM_OPT'; cannot produce runnable Lind artifact." >&2
+if [[ "$LIND_DYLINK" == "1" ]]; then
+  if [[ ! -x "$LIND_WASM_OPT" ]]; then
+    echo "[bash] ERROR: lind-wasm-opt not found at '$LIND_WASM_OPT'; cannot produce runnable Lind artifact." >&2
+    exit 1
+  fi
+elif [[ ! -x "$WASM_OPT" ]]; then
+  echo "[bash] ERROR: wasm-opt not found at '$WASM_OPT'; cannot produce runnable Lind artifact." >&2
   exit 1
 fi
 
@@ -561,7 +567,13 @@ if [[ "$LIND_DYLINK" == "1" ]]; then
   "$LIND_WASM_OPT" --target=main --fpcast-emu \
     "$BASH_RAW_WASM" -o "$BASH_WASM"
 else
-  "$LIND_WASM_OPT" --static --fpcast-emu \
+  # NOTE: static bash deliberately does NOT use `lind-wasm-opt --static`.
+  # lind-wasm-opt forces `--translate-to-exnref`, which breaks bash's
+  # longjmp-based control flow (while/until/break/continue/return and the
+  # `[ ]` test builtin) and regressed `make test APP=bash` from 157/162 to
+  # 132/162. The manual flag set below (no exnref translation) is the
+  # proven-working static build. See PR #266 discussion.
+  "$WASM_OPT" --epoch-injection --asyncify --fpcast-emu --debuginfo -O2 \
     "$BASH_RAW_WASM" -o "$BASH_WASM"
 fi
 

--- a/bash/compile_bash.sh
+++ b/bash/compile_bash.sh
@@ -41,6 +41,7 @@ AR="${AR:-"$LLVM_BIN_DIR/llvm-ar"}"
 RANLIB="${RANLIB:-"$LLVM_BIN_DIR/llvm-ranlib"}"
 
 WASM_OPT="${WASM_OPT:-$LIND_WASM_ROOT/tools/binaryen/bin/wasm-opt}"
+LIND_WASM_OPT="${LIND_WASM_OPT:-$LIND_WASM_ROOT/scripts/lind-wasm-opt}"
 LIND_BOOT="${LIND_BOOT:-$LIND_WASM_ROOT/build/lind-boot}"
 ADD_EXPORT_TOOL="${ADD_EXPORT_TOOL:-$LIND_WASM_ROOT/tools/add-export-tool/add-export-tool}"
 
@@ -548,8 +549,8 @@ fi
 # output for debugging as `bash.raw.wasm`, but write the runnable module to the
 # traditional `bash.wasm` path. Full mode still adds the extra alias and cwasm.
 ##################
-if [[ ! -x "$WASM_OPT" ]]; then
-  echo "[bash] ERROR: wasm-opt not found at '$WASM_OPT'; cannot produce runnable Lind artifact." >&2
+if [[ ! -x "$LIND_WASM_OPT" ]]; then
+  echo "[bash] ERROR: lind-wasm-opt not found at '$LIND_WASM_OPT'; cannot produce runnable Lind artifact." >&2
   exit 1
 fi
 
@@ -558,16 +559,10 @@ echo "[bash] running wasm-opt to produce runnable bash.wasm..."
 if [[ "$LIND_DYLINK" == "1" ]]; then
   # Shared modules require the import-table and import-globals passes so that
   # lind-dylink can patch relocations at load time.
-  "$WASM_OPT" \
-    --enable-bulk-memory --enable-threads --enable-exception-handling --enable-reference-types \
-    --epoch-injection --pass-arg=epoch-import --pass-arg=epoch-main-module \
-    --asyncify --pass-arg=asyncify-import-globals \
-    --fpcast-emu --pass-arg=relocatable-fpcast \
-    --translate-to-exnref \
-    --debuginfo -O2 \
+  "$LIND_WASM_OPT" --target=main --fpcast-emu \
     "$BASH_RAW_WASM" -o "$BASH_WASM"
 else
-  "$WASM_OPT" --epoch-injection --asyncify --fpcast-emu --debuginfo -O2 \
+  "$LIND_WASM_OPT" --static --fpcast-emu \
     "$BASH_RAW_WASM" -o "$BASH_WASM"
 fi
 

--- a/bash/compile_bash.sh
+++ b/bash/compile_bash.sh
@@ -40,7 +40,6 @@ LLVM_BIN_DIR="$(dirname "$CLANG")"
 AR="${AR:-"$LLVM_BIN_DIR/llvm-ar"}"
 RANLIB="${RANLIB:-"$LLVM_BIN_DIR/llvm-ranlib"}"
 
-WASM_OPT="${WASM_OPT:-$LIND_WASM_ROOT/tools/binaryen/bin/wasm-opt}"
 LIND_WASM_OPT="${LIND_WASM_OPT:-$LIND_WASM_ROOT/scripts/lind-wasm-opt}"
 LIND_BOOT="${LIND_BOOT:-$LIND_WASM_ROOT/build/lind-boot}"
 ADD_EXPORT_TOOL="${ADD_EXPORT_TOOL:-$LIND_WASM_ROOT/tools/add-export-tool/add-export-tool}"

--- a/bash/compile_bash.sh
+++ b/bash/compile_bash.sh
@@ -559,10 +559,11 @@ if [[ "$LIND_DYLINK" == "1" ]]; then
   # Shared modules require the import-table and import-globals passes so that
   # lind-dylink can patch relocations at load time.
   "$WASM_OPT" \
-    --enable-bulk-memory --enable-threads \
+    --enable-bulk-memory --enable-threads --enable-exception-handling --enable-reference-types \
     --epoch-injection --pass-arg=epoch-import --pass-arg=epoch-main-module \
     --asyncify --pass-arg=asyncify-import-globals \
     --fpcast-emu --pass-arg=relocatable-fpcast \
+    --translate-to-exnref \
     --debuginfo -O2 \
     "$BASH_RAW_WASM" -o "$BASH_WASM"
 else

--- a/bash/compile_bash.sh
+++ b/bash/compile_bash.sh
@@ -106,6 +106,12 @@ CFLAGS_WASM=(
   -I"$MERGED_SYSROOT/include/wasm32-wasi"
 )
 
+# EH-based setjmp/longjmp (default). The legacy asyncify-based path is
+# selected by setting LIND_ASYNCIFY_SETJMP=1, matching lind_compile behaviour.
+if [[ -z "${LIND_ASYNCIFY_SETJMP:-}" ]]; then
+  CFLAGS_WASM+=(-fwasm-exceptions -mllvm -wasm-enable-sjlj)
+fi
+
 # ----------------------------------------------------------------------
 # Branch Logic: Dynamic vs Static Settings
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/Lind-Project/lind-wasm-apps/issues/264 for bash

## Fix

Two changes in `bash/compile_bash.sh`:

1. **CFLAGS**: add `-fwasm-exceptions -mllvm -wasm-enable-sjlj`, guarded so the legacy
     asyncify path is still available via `LIND_ASYNCIFY_SETJMP=1` (matches `lind_compile`).
2. **wasm-opt (dylink path)**: add `--enable-exception-handling --enable-reference-types`
     to the enables and `--translate-to-exnref` as the final pass (after asyncify/fpcast).