### PR TITLE
Update app scripts to match lind-wasm scripts/ reorganization

### DIFF
--- a/cpython/run_tests.sh
+++ b/cpython/run_tests.sh
@@ -16,7 +16,7 @@ LINDFS_ROOT="${LINDFS_ROOT:-$LIND_WASM_ROOT/lindfs}"
 LIND_DYLINK="${LIND_DYLINK:-0}"
 BUILD_WASM="$SCRIPT_DIR/build-wasm"
 
-LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run"
+LIND_RUN="$LIND_WASM_ROOT/scripts/bin/lind_run"
 
 # --- verify build exists -----------------------------------------------------
 if [[ ! -f "$BUILD_WASM/Makefile" ]]; then

--- a/curl/run_tests.sh
+++ b/curl/run_tests.sh
@@ -29,9 +29,9 @@ fi
 LIND_DYLINK="${LIND_DYLINK:-0}"
 
 if [[ "$LIND_DYLINK" == "1" ]]; then
-        LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run --preload env=lib/libz.so --preload env=lib/libcrypto.so --preload env=lib/libssl.so"
+        LIND_RUN="$LIND_WASM_ROOT/scripts/bin/lind_run --preload env=lib/libz.so --preload env=lib/libcrypto.so --preload env=lib/libssl.so"
 else
-        LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run"
+        LIND_RUN="$LIND_WASM_ROOT/scripts/bin/lind_run"
 fi
 
 LINDFS_ROOT="$LIND_WASM_ROOT/lindfs"

--- a/git/run_tests.sh
+++ b/git/run_tests.sh
@@ -28,7 +28,7 @@ fi
 
 LIND_DYLINK="${LIND_DYLINK:-0}"
 
-LIND_RUN=("$LIND_WASM_ROOT/scripts/lind_run")
+LIND_RUN=("$LIND_WASM_ROOT/scripts/bin/lind_run")
 if [[ "$LIND_DYLINK" == "1" ]]; then
     # Dynamic builds need shared libs preloaded into the wasm env namespace.
     # These paths are relative to lindfs (installed by make install).

--- a/gnulib/compile_gnulib.sh
+++ b/gnulib/compile_gnulib.sh
@@ -200,7 +200,7 @@ if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
 fi
 
 # do precompile
-$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[gnulib] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2; exit 1; }
+$LIND_WASM_ROOT/scripts/bin/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[gnulib] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2; exit 1; }
 
 if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
   echo "[gnulib] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2

--- a/grep/run_tests.sh
+++ b/grep/run_tests.sh
@@ -19,7 +19,7 @@ APPS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 LIND_WASM_ROOT="${LIND_WASM_ROOT:-$(cd "$APPS_ROOT/.." && pwd)}"
 STAGE_DIR="$APPS_ROOT/build/grep/usr/local/bin"
 LINDFS_ROOT="$LIND_WASM_ROOT/lindfs"
-LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run"
+LIND_RUN="$LIND_WASM_ROOT/scripts/bin/lind_run"
 GREP_BIN="/usr/local/bin/grep"
 TEST_DIR="/tests/grep"
 

--- a/libtirpc/compile_libtirpc.sh
+++ b/libtirpc/compile_libtirpc.sh
@@ -114,7 +114,7 @@ if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
 fi
 
 # do precompile
-$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[libtirpc] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2; exit 1; }
+$LIND_WASM_ROOT/scripts/bin/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[libtirpc] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2; exit 1; }
 
 if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
   echo "[libtirpc] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2

--- a/lmbench/run_tests.sh
+++ b/lmbench/run_tests.sh
@@ -42,12 +42,12 @@ resolve_lind_wasm_root() {
         return 0
     fi
 
-    if [[ -f "$APPS_ROOT/../scripts/lind_run" && -f "$APPS_ROOT/../Makefile" ]]; then
+    if [[ -f "$APPS_ROOT/../scripts/bin/lind_run" && -f "$APPS_ROOT/../Makefile" ]]; then
         (cd "$APPS_ROOT/.." && pwd)
         return 0
     fi
 
-    if [[ -f "$APPS_ROOT/../lind-wasm/scripts/lind_run" && -f "$APPS_ROOT/../lind-wasm/Makefile" ]]; then
+    if [[ -f "$APPS_ROOT/../lind-wasm/scripts/bin/lind_run" && -f "$APPS_ROOT/../lind-wasm/Makefile" ]]; then
         (cd "$APPS_ROOT/../lind-wasm" && pwd)
         return 0
     fi
@@ -57,7 +57,7 @@ resolve_lind_wasm_root() {
 
 LIND_WASM_ROOT="${LIND_WASM_ROOT:-$(resolve_lind_wasm_root 2>/dev/null || true)}"
 LINDFS_ROOT="$LIND_WASM_ROOT/lindfs"
-LIND_RUN="${LIND_RUN:-$LIND_WASM_ROOT/scripts/lind_run}"
+LIND_RUN="${LIND_RUN:-$LIND_WASM_ROOT/scripts/bin/lind_run}"
 BUILD_BIN_DIR="$APPS_ROOT/build/lmbench/bin"
 TEST_LIST_FILE="${TEST_LIST_FILE:-$SCRIPT_DIR/test-binaries.txt}"
 LOG_FILE="${LOG_FILE:-$SCRIPT_DIR/lmbench_test.log}"

--- a/nginx/compile_nginx.sh
+++ b/nginx/compile_nginx.sh
@@ -1002,7 +1002,7 @@ echo "[nginx] build complete. Outputs:"
 ls -lh "$NGINX_OUT_DIR"/*.wasm 2>/dev/null || true
 echo
 echo "To run nginx in Lind:"
-echo "  $LIND_WASM_ROOT/scripts/lind_run usr/sbin/nginx -c /etc/nginx/nginx.conf"
+echo "  $LIND_WASM_ROOT/scripts/bin/lind_run usr/sbin/nginx -c /etc/nginx/nginx.conf"
 echo
 echo "Or with the test config:"
-echo "  $LIND_WASM_ROOT/scripts/lind_run usr/sbin/nginx -c /etc/nginx/nginx-wasm.conf"
+echo "  $LIND_WASM_ROOT/scripts/bin/lind_run usr/sbin/nginx -c /etc/nginx/nginx-wasm.conf"

--- a/nginx/run_tests.sh
+++ b/nginx/run_tests.sh
@@ -20,7 +20,7 @@ APPS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 if [[ -z "${LIND_WASM_ROOT:-}" ]]; then
     LIND_WASM_ROOT="$(cd "$APPS_ROOT/.." && pwd)"
 fi
-LIND_RUN="$LIND_WASM_ROOT/scripts/lind_run"
+LIND_RUN="$LIND_WASM_ROOT/scripts/bin/lind_run"
 LINDFS_ROOT="$LIND_WASM_ROOT/lindfs"
 NGINX_BIN="usr/sbin/nginx"
 NGINX_CONF_DIR="$LINDFS_ROOT/etc/nginx"

--- a/openssl/compile_openssl.sh
+++ b/openssl/compile_openssl.sh
@@ -116,7 +116,7 @@ if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
 fi
 
 # do precompile
-$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[openssl] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2; exit 1; }
+$LIND_WASM_ROOT/scripts/bin/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[openssl] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2; exit 1; }
 
 if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
   echo "[openssl] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2
@@ -168,7 +168,7 @@ if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
 fi
 
 # do precompile
-$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[openssl] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2; exit 1; }
+$LIND_WASM_ROOT/scripts/bin/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[openssl] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2; exit 1; }
 
 if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
   echo "[openssl] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2

--- a/postgres/compile_postgres.sh
+++ b/postgres/compile_postgres.sh
@@ -40,7 +40,7 @@ if [[ -z "${LIND_WASM_ROOT:-}" ]]; then
   LIND_WASM_ROOT="$(cd "$APPS_ROOT/.." && pwd)"
 fi
 
-LIND_WASM_OPT="${LIND_WASM_OPT:-$LIND_WASM_ROOT/scripts/lind-wasm-opt}"
+LIND_WASM_OPT="${LIND_WASM_OPT:-$LIND_WASM_ROOT/scripts/bin/lind-wasm-opt}"
 LIND_BOOT="${LIND_BOOT:-$LIND_WASM_ROOT/build/lind-boot}"
 ADD_EXPORT_TOOL="${ADD_EXPORT_TOOL:-$LIND_WASM_ROOT/tools/add-export-tool/add-export-tool}"
 

--- a/zlib/compile_zlib.sh
+++ b/zlib/compile_zlib.sh
@@ -103,7 +103,7 @@ if [[ ! -f "$DYNAMIC_LIB_OPT" ]]; then
 fi
 
 # do precompile
-$LIND_WASM_ROOT/scripts/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[zlib] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2; exit 1; }
+$LIND_WASM_ROOT/scripts/bin/lind_compile --precompile-only "$DYNAMIC_LIB_OPT" || { echo "[zlib] ERROR: lind_compile failed on '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2; exit 1; }
 
 if [[ ! -f "$DYNAMIC_LIB_OPT_CWASM" ]]; then
   echo "[zlib] ERROR: Failed to generate '$DYNAMIC_LIB_OPT_CWASM'; Exiting.." >&2


### PR DESCRIPTION
## Summary

Following the reorganization of scripts in the main `lind-wasm` repository
(Lind-Project/lind-wasm#1237), this PR updates all app build/test scripts to
reference the new `scripts/bin/` location instead of the old top-level
`scripts/` location.

Closes #268

## Changes

Mechanical path update across all app scripts:

| Old path | New path |
|---|---|
| `scripts/lind_run` | `scripts/bin/lind_run` |
| `scripts/lind_compile` | `scripts/bin/lind_compile` |
| `scripts/lind-wasm-opt` | `scripts/bin/lind-wasm-opt` |

**Files updated:**
- `cpython/run_tests.sh`
- `curl/run_tests.sh`
- `git/run_tests.sh`
- `gnulib/compile_gnulib.sh`
- `grep/run_tests.sh`
- `libtirpc/compile_libtirpc.sh`
- `lmbench/run_tests.sh`
- `nginx/compile_nginx.sh` + `nginx/run_tests.sh`
- `openssl/compile_openssl.sh`
- `postgres/compile_postgres.sh`
- `zlib/compile_zlib.sh`

## Testing
- Scanned all `*.sh` and `Makefile` files in
  `lind-wasm-apps` for `$LIND_WASM_ROOT/scripts/...` references and checks
  that each path exists on disk under the reorganized `scripts/bin/` layout.
  All references resolved successfully (0 failures).
- Executed `make <app>`, `make install-<app>`, and
  `make test APP=<app>` for every app script changed and verified that no 'file/directory not found' errors occured